### PR TITLE
Improve coverage fallback and chain validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,17 @@
         "phpstan/phpstan-deprecation-rules": "^1.1"
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "@php -r \"if (!extension_loaded('xdebug') && !extension_loaded('pcov')) { fwrite(STDERR, 'No code coverage driver available; running without coverage.' . PHP_EOL); passthru('vendor/bin/phpunit', $status); exit($status); } if (extension_loaded('xdebug')) { putenv('XDEBUG_MODE=coverage'); } passthru('vendor/bin/phpunit --coverage-text', $status); exit($status);\"",
         "analyse": [
             "@phpstan",
             "@phpstan-deprecation"
         ],
-        "phpstan": "phpstan analyse --configuration=phpstan.neon.dist",
-        "phpstan-deprecation": "phpstan analyse --configuration=phpstan-deprecation.neon"
+        "check": [
+            "@analyse",
+            "@test"
+        ],
+        "phpstan": "vendor/bin/phpstan analyse --configuration=phpstan.neon.dist",
+        "phpstan-deprecation": "vendor/bin/phpstan analyse --configuration=phpstan-deprecation.neon"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="Unit Tests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit Tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Contracts/CalculationRequest.php
+++ b/src/Contracts/CalculationRequest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Contracts;
+
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+
+final class CalculationRequest
+{
+    private string $strategyName;
+
+    private CalculationDirection $direction;
+
+    private string $amount;
+
+    /** @var array<string, mixed> */
+    private array $context;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function __construct(string $strategyName, CalculationDirection $direction, string $amount, array $context = [])
+    {
+        $strategyName = trim($strategyName);
+        if ($strategyName === '') {
+            throw ValidationException::emptyStrategyName();
+        }
+
+        $this->strategyName = $strategyName;
+        $this->direction = $direction;
+        $this->amount = $this->assertNumericString($amount);
+        $this->context = $context;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public static function forward(string $strategyName, string $amount, array $context = []): self
+    {
+        return new self($strategyName, CalculationDirection::FORWARD, $amount, $context);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public static function backward(string $strategyName, string $amount, array $context = []): self
+    {
+        return new self($strategyName, CalculationDirection::BACKWARD, $amount, $context);
+    }
+
+    public function getStrategyName(): string
+    {
+        return $this->strategyName;
+    }
+
+    public function getDirection(): CalculationDirection
+    {
+        return $this->direction;
+    }
+
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    public function withAmount(string $amount): self
+    {
+        return new self($this->strategyName, $this->direction, $amount, $this->context);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function withContext(array $context): self
+    {
+        return new self($this->strategyName, $this->direction, $this->amount, $context);
+    }
+
+    private function assertNumericString(string $amount): string
+    {
+        if (!preg_match('/^-?\d+(?:\.\d+)?$/', $amount)) {
+            throw ValidationException::invalidAmount($amount);
+        }
+
+        return $amount;
+    }
+}

--- a/src/Contracts/CalculationResult.php
+++ b/src/Contracts/CalculationResult.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Contracts;
+
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+final class CalculationResult
+{
+    private string $baseAmount;
+
+    private string $feeAmount;
+
+    private string $totalAmount;
+
+    private CalculationDirection $direction;
+
+    /** @var array<string, mixed> */
+    private array $context;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function __construct(
+        string $baseAmount,
+        string $feeAmount,
+        string $totalAmount,
+        CalculationDirection $direction,
+        array $context = []
+    ) {
+        $this->baseAmount = $baseAmount;
+        $this->feeAmount = $feeAmount;
+        $this->totalAmount = $totalAmount;
+        $this->direction = $direction;
+        $this->context = $context;
+    }
+
+    public function getBaseAmount(): string
+    {
+        return $this->baseAmount;
+    }
+
+    public function getFeeAmount(): string
+    {
+        return $this->feeAmount;
+    }
+
+    public function getTotalAmount(): string
+    {
+        return $this->totalAmount;
+    }
+
+    public function getDirection(): CalculationDirection
+    {
+        return $this->direction;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    public function withAmounts(string $baseAmount, string $feeAmount, string $totalAmount): self
+    {
+        return new self($baseAmount, $feeAmount, $totalAmount, $this->direction, $this->context);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function withContext(array $context): self
+    {
+        return new self($this->baseAmount, $this->feeAmount, $this->totalAmount, $this->direction, $context);
+    }
+}

--- a/src/Contracts/Chain/CalculationChainRequest.php
+++ b/src/Contracts/Chain/CalculationChainRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Contracts\Chain;
+
+use SomeWork\FeeCalculator\Enum\ChainStepInputSource;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+
+final class CalculationChainRequest
+{
+    private string $initialAmount;
+
+    /** @var list<CalculationChainStep> */
+    private array $steps;
+
+    public function __construct(string $initialAmount, CalculationChainStep ...$steps)
+    {
+        $this->initialAmount = $this->assertNumericString($initialAmount);
+
+        if ($steps === []) {
+            throw ValidationException::emptyCalculationChain();
+        }
+
+        $steps = array_values($steps);
+
+        /** @var list<CalculationChainStep> $steps */
+
+        foreach ($steps as $index => $step) {
+            $inputSource = $step->getInputSource();
+
+            if ($index === 0 && $inputSource !== ChainStepInputSource::INITIAL) {
+                throw ValidationException::invalidFirstStepInputSource($inputSource->name);
+            }
+
+            if ($index > 0 && $inputSource === ChainStepInputSource::INITIAL) {
+                throw ValidationException::invalidSubsequentStepInputSource($index + 1, $inputSource->name);
+            }
+        }
+
+        $this->steps = $steps;
+    }
+
+    public function getInitialAmount(): string
+    {
+        return $this->initialAmount;
+    }
+
+    /**
+     * @return list<CalculationChainStep>
+     */
+    public function getSteps(): array
+    {
+        return $this->steps;
+    }
+
+    private function assertNumericString(string $amount): string
+    {
+        if (!preg_match('/^-?\d+(?:\.\d+)?$/', $amount)) {
+            throw ValidationException::invalidAmount($amount);
+        }
+
+        return $amount;
+    }
+}

--- a/src/Contracts/Chain/CalculationChainResult.php
+++ b/src/Contracts/Chain/CalculationChainResult.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Contracts\Chain;
+
+final class CalculationChainResult
+{
+    private string $initialAmount;
+
+    private string $finalAmount;
+
+    /** @var list<CalculationChainStepResult> */
+    private array $steps;
+
+    /**
+     * @param list<CalculationChainStepResult> $steps
+     */
+    public function __construct(string $initialAmount, string $finalAmount, array $steps)
+    {
+        $this->initialAmount = $initialAmount;
+        $this->finalAmount = $finalAmount;
+        $this->steps = $steps;
+    }
+
+    public function getInitialAmount(): string
+    {
+        return $this->initialAmount;
+    }
+
+    public function getFinalAmount(): string
+    {
+        return $this->finalAmount;
+    }
+
+    /**
+     * @return list<CalculationChainStepResult>
+     */
+    public function getSteps(): array
+    {
+        return $this->steps;
+    }
+
+    public function getLastStepResult(): ?CalculationChainStepResult
+    {
+        if ($this->steps === []) {
+            return null;
+        }
+
+        return $this->steps[array_key_last($this->steps)];
+    }
+}

--- a/src/Contracts/Chain/CalculationChainStep.php
+++ b/src/Contracts/Chain/CalculationChainStep.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Contracts\Chain;
+
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Enum\ChainResultSelection;
+use SomeWork\FeeCalculator\Enum\ChainStepInputSource;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+
+final class CalculationChainStep
+{
+    private string $identifier;
+
+    private string $strategyName;
+
+    private CalculationDirection $direction;
+
+    private ChainStepInputSource $inputSource;
+
+    private ChainResultSelection $outputSelection;
+
+    /** @var array<string, mixed> */
+    private array $context;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function __construct(
+        string $identifier,
+        string $strategyName,
+        CalculationDirection $direction,
+        ChainStepInputSource $inputSource = ChainStepInputSource::PREVIOUS_OUTPUT,
+        ChainResultSelection $outputSelection = ChainResultSelection::TOTAL,
+        array $context = []
+    ) {
+        $identifier = trim($identifier);
+        if ($identifier === '') {
+            throw ValidationException::emptyChainStepIdentifier();
+        }
+
+        $strategyName = trim($strategyName);
+        if ($strategyName === '') {
+            throw ValidationException::emptyStrategyName();
+        }
+
+        $this->identifier = $identifier;
+        $this->strategyName = $strategyName;
+        $this->direction = $direction;
+        $this->inputSource = $inputSource;
+        $this->outputSelection = $outputSelection;
+        $this->context = $context;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getStrategyName(): string
+    {
+        return $this->strategyName;
+    }
+
+    public function getDirection(): CalculationDirection
+    {
+        return $this->direction;
+    }
+
+    public function getInputSource(): ChainStepInputSource
+    {
+        return $this->inputSource;
+    }
+
+    public function getOutputSelection(): ChainResultSelection
+    {
+        return $this->outputSelection;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function withContext(array $context): self
+    {
+        return new self(
+            $this->identifier,
+            $this->strategyName,
+            $this->direction,
+            $this->inputSource,
+            $this->outputSelection,
+            $context
+        );
+    }
+}

--- a/src/Contracts/Chain/CalculationChainStepResult.php
+++ b/src/Contracts/Chain/CalculationChainStepResult.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Contracts\Chain;
+
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Enum\ChainResultSelection;
+
+final class CalculationChainStepResult
+{
+    private CalculationChainStep $step;
+
+    private string $inputAmount;
+
+    private CalculationResult $result;
+
+    public function __construct(CalculationChainStep $step, string $inputAmount, CalculationResult $result)
+    {
+        $this->step = $step;
+        $this->inputAmount = $inputAmount;
+        $this->result = $result;
+    }
+
+    public function getStep(): CalculationChainStep
+    {
+        return $this->step;
+    }
+
+    public function getInputAmount(): string
+    {
+        return $this->inputAmount;
+    }
+
+    public function getResult(): CalculationResult
+    {
+        return $this->result;
+    }
+
+    public function getOutputAmount(): string
+    {
+        return match ($this->step->getOutputSelection()) {
+            ChainResultSelection::BASE => $this->result->getBaseAmount(),
+            ChainResultSelection::TOTAL => $this->result->getTotalAmount(),
+            ChainResultSelection::FEE => $this->result->getFeeAmount(),
+        };
+    }
+}

--- a/src/Contracts/FeeStrategyInterface.php
+++ b/src/Contracts/FeeStrategyInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Contracts;
+
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+interface FeeStrategyInterface
+{
+    public function getName(): string;
+
+    public function supportsDirection(CalculationDirection $direction): bool;
+
+    public function calculateForward(CalculationRequest $request): CalculationResult;
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult;
+}

--- a/src/Enum/CalculationDirection.php
+++ b/src/Enum/CalculationDirection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Enum;
+
+enum CalculationDirection: string
+{
+    case FORWARD = 'forward';
+    case BACKWARD = 'backward';
+
+    public function isForward(): bool
+    {
+        return $this === self::FORWARD;
+    }
+
+    public function isBackward(): bool
+    {
+        return $this === self::BACKWARD;
+    }
+}

--- a/src/Enum/ChainResultSelection.php
+++ b/src/Enum/ChainResultSelection.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Enum;
+
+enum ChainResultSelection: string
+{
+    case BASE = 'base';
+    case TOTAL = 'total';
+    case FEE = 'fee';
+}

--- a/src/Enum/ChainStepInputSource.php
+++ b/src/Enum/ChainStepInputSource.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Enum;
+
+enum ChainStepInputSource: string
+{
+    case INITIAL = 'initial';
+    case PREVIOUS_OUTPUT = 'previous_output';
+    case PREVIOUS_BASE = 'previous_base';
+    case PREVIOUS_TOTAL = 'previous_total';
+    case PREVIOUS_FEE = 'previous_fee';
+}

--- a/src/Exception/FeeCalculatorException.php
+++ b/src/Exception/FeeCalculatorException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Exception;
+
+use RuntimeException;
+
+class FeeCalculatorException extends RuntimeException
+{
+}

--- a/src/Exception/StrategyNotFoundException.php
+++ b/src/Exception/StrategyNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Exception;
+
+class StrategyNotFoundException extends FeeCalculatorException
+{
+    public static function named(string $name): self
+    {
+        return new self(sprintf('No fee strategy registered with the name "%s".', $name));
+    }
+}

--- a/src/Exception/UnsupportedCalculationDirectionException.php
+++ b/src/Exception/UnsupportedCalculationDirectionException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Exception;
+
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+class UnsupportedCalculationDirectionException extends FeeCalculatorException
+{
+    public static function forStrategy(string $strategyName, CalculationDirection $direction): self
+    {
+        return new self(sprintf('Strategy "%s" does not support "%s" calculations.', $strategyName, $direction->value));
+    }
+}

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Exception;
+
+use InvalidArgumentException;
+
+class ValidationException extends InvalidArgumentException
+{
+    public static function emptyStrategyName(): self
+    {
+        return new self('The strategy name must not be empty.');
+    }
+
+    public static function invalidAmount(string $amount): self
+    {
+        return new self(sprintf('The provided amount "%s" is not a valid numeric string.', $amount));
+    }
+
+    public static function invalidScale(int $scale): self
+    {
+        return new self(sprintf('The scale "%d" must be greater than or equal to zero.', $scale));
+    }
+
+    public static function emptyCalculationChain(): self
+    {
+        return new self('The calculation chain must contain at least one step.');
+    }
+
+    public static function emptyChainStepIdentifier(): self
+    {
+        return new self('The step identifier must not be empty.');
+    }
+
+    public static function invalidFirstStepInputSource(string $source): self
+    {
+        return new self(sprintf('The first step must use the "INITIAL" input source, "%s" given.', $source));
+    }
+
+    public static function invalidSubsequentStepInputSource(int $position, string $source): self
+    {
+        return new self(sprintf('Only the first step may use the "INITIAL" input source; step #%d configured "%s".', $position, $source));
+    }
+
+    public static function missingPreviousStepResult(int $position, string $source): self
+    {
+        return new self(sprintf('Step #%d expects a previous result for source "%s", but none is available.', $position, $source));
+    }
+
+    public static function missingPreviousStepOutput(int $position): self
+    {
+        return new self(sprintf('Step #%d expects an output value from the previous step, but none is available.', $position));
+    }
+}

--- a/src/FeeCalculationChain.php
+++ b/src/FeeCalculationChain.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator;
+
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainRequest;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainResult;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainStep;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainStepResult;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Enum\ChainStepInputSource;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+
+final class FeeCalculationChain
+{
+    private FeeCalculator $calculator;
+
+    public function __construct(FeeCalculator $calculator)
+    {
+        $this->calculator = $calculator;
+    }
+
+    public function calculate(CalculationChainRequest $request): CalculationChainResult
+    {
+        $stepResults = [];
+        $previousResult = null;
+        $previousOutputAmount = null;
+
+        foreach ($request->getSteps() as $index => $step) {
+            $inputAmount = $this->resolveInputAmount($request, $step, $previousResult, $previousOutputAmount, $index);
+
+            $calculationRequest = new CalculationRequest(
+                $step->getStrategyName(),
+                $step->getDirection(),
+                $inputAmount,
+                $step->getContext()
+            );
+
+            $result = $this->calculator->calculate($calculationRequest);
+
+            $stepResult = new CalculationChainStepResult($step, $inputAmount, $result);
+            $stepResults[] = $stepResult;
+
+            $previousResult = $result;
+            $previousOutputAmount = $stepResult->getOutputAmount();
+        }
+
+        $initialAmount = $this->calculator->normalizeAmount($request->getInitialAmount());
+        $finalAmount = $previousOutputAmount ?? $initialAmount;
+
+        return new CalculationChainResult($initialAmount, $finalAmount, $stepResults);
+    }
+
+    private function resolveInputAmount(
+        CalculationChainRequest $chainRequest,
+        CalculationChainStep $step,
+        ?CalculationResult $previousResult,
+        ?string $previousOutputAmount,
+        int $index
+    ): string {
+        return match ($step->getInputSource()) {
+            ChainStepInputSource::INITIAL => $chainRequest->getInitialAmount(),
+            ChainStepInputSource::PREVIOUS_OUTPUT => $this->requirePreviousOutput($previousOutputAmount, $index),
+            ChainStepInputSource::PREVIOUS_BASE => $this->requirePreviousResult($previousResult, $index, ChainStepInputSource::PREVIOUS_BASE)->getBaseAmount(),
+            ChainStepInputSource::PREVIOUS_TOTAL => $this->requirePreviousResult($previousResult, $index, ChainStepInputSource::PREVIOUS_TOTAL)->getTotalAmount(),
+            ChainStepInputSource::PREVIOUS_FEE => $this->requirePreviousResult($previousResult, $index, ChainStepInputSource::PREVIOUS_FEE)->getFeeAmount(),
+        };
+    }
+
+    private function requirePreviousOutput(?string $output, int $index): string
+    {
+        if ($output === null) {
+            throw ValidationException::missingPreviousStepOutput($index + 1);
+        }
+
+        return $output;
+    }
+
+    private function requirePreviousResult(?CalculationResult $result, int $index, ChainStepInputSource $source): CalculationResult
+    {
+        if ($result === null) {
+            throw ValidationException::missingPreviousStepResult($index + 1, $source->name);
+        }
+
+        return $result;
+    }
+}

--- a/src/FeeCalculator.php
+++ b/src/FeeCalculator.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator;
+
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Exception\UnsupportedCalculationDirectionException;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+use SomeWork\FeeCalculator\Registry\StrategyRegistry;
+
+final class FeeCalculator
+{
+    private StrategyRegistry $registry;
+
+    private int $scale;
+
+    public function __construct(StrategyRegistry $registry, int $scale = 2)
+    {
+        if ($scale < 0) {
+            throw ValidationException::invalidScale($scale);
+        }
+
+        $this->registry = $registry;
+        $this->scale = $scale;
+    }
+
+    public function calculate(CalculationRequest $request): CalculationResult
+    {
+        $strategy = $this->registry->get($request->getStrategyName());
+
+        $direction = $request->getDirection();
+        if (!$strategy->supportsDirection($direction)) {
+            throw UnsupportedCalculationDirectionException::forStrategy($strategy->getName(), $direction);
+        }
+
+        $normalizedRequest = $request->withAmount($this->normalize($request->getAmount()));
+
+        $result = match ($direction) {
+            CalculationDirection::FORWARD => $strategy->calculateForward($normalizedRequest),
+            CalculationDirection::BACKWARD => $strategy->calculateBackward($normalizedRequest),
+        };
+
+        return $result->withAmounts(
+            $this->normalize($result->getBaseAmount()),
+            $this->normalize($result->getFeeAmount()),
+            $this->normalize($result->getTotalAmount())
+        );
+    }
+
+    public function normalizeAmount(string $value): string
+    {
+        return $this->normalize($value);
+    }
+
+    private function normalize(string $value): string
+    {
+        if (!preg_match('/^-?\d+(?:\.\d+)?$/', $value)) {
+            throw ValidationException::invalidAmount($value);
+        }
+
+        return bcadd($value, '0', $this->scale);
+    }
+}

--- a/src/Registry/StrategyRegistry.php
+++ b/src/Registry/StrategyRegistry.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Registry;
+
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Exception\StrategyNotFoundException;
+
+final class StrategyRegistry
+{
+    /** @var array<string, FeeStrategyInterface> */
+    private array $strategies = [];
+
+    /**
+     * @param iterable<FeeStrategyInterface> $strategies
+     */
+    public function __construct(iterable $strategies = [])
+    {
+        foreach ($strategies as $strategy) {
+            $this->register($strategy);
+        }
+    }
+
+    public function register(FeeStrategyInterface $strategy): void
+    {
+        $this->strategies[$strategy->getName()] = $strategy;
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->strategies);
+    }
+
+    public function get(string $name): FeeStrategyInterface
+    {
+        if (!$this->has($name)) {
+            throw StrategyNotFoundException::named($name);
+        }
+
+        return $this->strategies[$name];
+    }
+
+    /**
+     * @return array<string, FeeStrategyInterface>
+     */
+    public function all(): array
+    {
+        return $this->strategies;
+    }
+}

--- a/tests/Integration/FeeCalculatorIntegrationTest.php
+++ b/tests/Integration/FeeCalculatorIntegrationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\FeeCalculator;
+use SomeWork\FeeCalculator\Registry\StrategyRegistry;
+
+final class FeeCalculatorIntegrationTest extends TestCase
+{
+    public function testForwardAndBackwardCalculationsWithPercentageStrategy(): void
+    {
+        $strategy = new PercentageFeeStrategy();
+        $calculator = new FeeCalculator(new StrategyRegistry([$strategy]), 4);
+
+        $forwardRequest = CalculationRequest::forward('percentage', '100', ['rate' => '0.05']);
+        $forwardResult = $calculator->calculate($forwardRequest);
+
+        self::assertSame('100.0000', $forwardResult->getBaseAmount());
+        self::assertSame('5.0000', $forwardResult->getFeeAmount());
+        self::assertSame('105.0000', $forwardResult->getTotalAmount());
+        self::assertSame(['rate' => '0.05'], $forwardResult->getContext());
+
+        $backwardRequest = CalculationRequest::backward('percentage', '210', ['rate' => '0.20']);
+        $backwardResult = $calculator->calculate($backwardRequest);
+
+        self::assertSame('175.0000', $backwardResult->getBaseAmount());
+        self::assertSame('35.0000', $backwardResult->getFeeAmount());
+        self::assertSame('210.0000', $backwardResult->getTotalAmount());
+        self::assertSame(['rate' => '0.20'], $backwardResult->getContext());
+    }
+}
+
+final class PercentageFeeStrategy implements FeeStrategyInterface
+{
+    public function getName(): string
+    {
+        return 'percentage';
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        return true;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        $rate = $this->getRate($request);
+        $base = $request->getAmount();
+        $fee = bcmul($base, $rate, 6);
+        $total = bcadd($base, $fee, 6);
+
+        return new CalculationResult($base, $fee, $total, CalculationDirection::FORWARD, ['rate' => $rate]);
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        $rate = $this->getRate($request);
+        $total = $request->getAmount();
+        $divider = bcadd('1', $rate, 6);
+        $base = bcdiv($total, $divider, 6);
+        $fee = bcsub($total, $base, 6);
+
+        return new CalculationResult($base, $fee, $total, CalculationDirection::BACKWARD, ['rate' => $rate]);
+    }
+
+    private function getRate(CalculationRequest $request): string
+    {
+        /** @var array<string, mixed> $context */
+        $context = $request->getContext();
+
+        if (!array_key_exists('rate', $context)) {
+            throw new \InvalidArgumentException('Rate must be provided.');
+        }
+
+        $value = $context['rate'];
+
+        if (!is_string($value)) {
+            if (!is_numeric($value)) {
+                throw new \InvalidArgumentException('Rate must be numeric.');
+            }
+
+            $value = (string) $value;
+        }
+
+        return $value;
+    }
+}

--- a/tests/Unit/CalculationChainRequestTest.php
+++ b/tests/Unit/CalculationChainRequestTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainRequest;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainStep;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Enum\ChainStepInputSource;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+
+final class CalculationChainRequestTest extends TestCase
+{
+    public function testConstructsRequest(): void
+    {
+        $request = new CalculationChainRequest(
+            '100.5',
+            new CalculationChainStep(
+                'conversion',
+                'percentage',
+                CalculationDirection::FORWARD,
+                ChainStepInputSource::INITIAL
+            ),
+            new CalculationChainStep(
+                'withdrawal',
+                'flat',
+                CalculationDirection::FORWARD,
+                ChainStepInputSource::PREVIOUS_OUTPUT
+            )
+        );
+
+        self::assertSame('100.5', $request->getInitialAmount());
+        self::assertCount(2, $request->getSteps());
+    }
+
+    public function testRejectsEmptyStepList(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The calculation chain must contain at least one step.');
+
+        new CalculationChainRequest('10', ...[]);
+    }
+
+    public function testRejectsInvalidInitialAmount(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The provided amount "ten" is not a valid numeric string.');
+
+        new CalculationChainRequest('ten', new CalculationChainStep(
+            'first',
+            'strategy',
+            CalculationDirection::FORWARD,
+            ChainStepInputSource::INITIAL
+        ));
+    }
+
+    public function testFirstStepMustUseInitialSource(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The first step must use the "INITIAL" input source, "PREVIOUS_OUTPUT" given.');
+
+        new CalculationChainRequest('10', new CalculationChainStep(
+            'first',
+            'strategy',
+            CalculationDirection::FORWARD,
+            ChainStepInputSource::PREVIOUS_OUTPUT
+        ));
+    }
+
+    public function testSubsequentStepCannotUseInitialSource(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Only the first step may use the "INITIAL" input source; step #2 configured "INITIAL".');
+
+        new CalculationChainRequest(
+            '10',
+            new CalculationChainStep(
+                'first',
+                'strategy',
+                CalculationDirection::FORWARD,
+                ChainStepInputSource::INITIAL
+            ),
+            new CalculationChainStep(
+                'second',
+                'strategy',
+                CalculationDirection::FORWARD,
+                ChainStepInputSource::INITIAL
+            )
+        );
+    }
+}

--- a/tests/Unit/CalculationChainResultTest.php
+++ b/tests/Unit/CalculationChainResultTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainResult;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainStep;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainStepResult;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Enum\ChainResultSelection;
+use SomeWork\FeeCalculator\Enum\ChainStepInputSource;
+
+final class CalculationChainResultTest extends TestCase
+{
+    public function testReturnsLastStepWhenAvailable(): void
+    {
+        $step = new CalculationChainStep(
+            'first',
+            'strategy',
+            CalculationDirection::FORWARD,
+            ChainStepInputSource::INITIAL,
+            ChainResultSelection::TOTAL
+        );
+
+        $result = new CalculationResult('10', '1', '11', CalculationDirection::FORWARD);
+        $stepResult = new CalculationChainStepResult($step, '10', $result);
+
+        $chain = new CalculationChainResult('10', '11', [$stepResult]);
+
+        self::assertSame($stepResult, $chain->getLastStepResult());
+    }
+
+    public function testReturnsNullWhenNoSteps(): void
+    {
+        $chain = new CalculationChainResult('10', '10', []);
+
+        self::assertNull($chain->getLastStepResult());
+    }
+}

--- a/tests/Unit/CalculationChainStepTest.php
+++ b/tests/Unit/CalculationChainStepTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainStep;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Enum\ChainResultSelection;
+use SomeWork\FeeCalculator\Enum\ChainStepInputSource;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+
+final class CalculationChainStepTest extends TestCase
+{
+    public function testConstructsStepWithNormalizedValues(): void
+    {
+        $step = new CalculationChainStep(
+            '  convert  ',
+            '  percentage  ',
+            CalculationDirection::FORWARD,
+            ChainStepInputSource::INITIAL,
+            ChainResultSelection::TOTAL,
+            ['currency' => 'USD']
+        );
+
+        self::assertSame('convert', $step->getIdentifier());
+        self::assertSame('percentage', $step->getStrategyName());
+        self::assertSame(CalculationDirection::FORWARD, $step->getDirection());
+        self::assertSame(ChainStepInputSource::INITIAL, $step->getInputSource());
+        self::assertSame(ChainResultSelection::TOTAL, $step->getOutputSelection());
+        self::assertSame(['currency' => 'USD'], $step->getContext());
+    }
+
+    public function testWithContextProducesNewInstance(): void
+    {
+        $original = new CalculationChainStep(
+            'withdrawal',
+            'flat',
+            CalculationDirection::BACKWARD,
+            ChainStepInputSource::PREVIOUS_TOTAL,
+            ChainResultSelection::BASE
+        );
+
+        $clone = $original->withContext(['fee' => '1.5']);
+
+        self::assertNotSame($original, $clone);
+        self::assertSame(['fee' => '1.5'], $clone->getContext());
+        self::assertSame([], $original->getContext());
+    }
+
+    public function testEmptyIdentifierThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The step identifier must not be empty.');
+
+        new CalculationChainStep(
+            '   ',
+            'strategy',
+            CalculationDirection::FORWARD,
+            ChainStepInputSource::INITIAL
+        );
+    }
+
+    public function testEmptyStrategyNameThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The strategy name must not be empty.');
+
+        new CalculationChainStep(
+            'step',
+            '   ',
+            CalculationDirection::FORWARD,
+            ChainStepInputSource::INITIAL
+        );
+    }
+}

--- a/tests/Unit/CalculationDirectionTest.php
+++ b/tests/Unit/CalculationDirectionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+final class CalculationDirectionTest extends TestCase
+{
+    public function testDirectionHelpers(): void
+    {
+        self::assertTrue(CalculationDirection::FORWARD->isForward());
+        self::assertFalse(CalculationDirection::FORWARD->isBackward());
+        self::assertTrue(CalculationDirection::BACKWARD->isBackward());
+        self::assertFalse(CalculationDirection::BACKWARD->isForward());
+    }
+}

--- a/tests/Unit/CalculationRequestTest.php
+++ b/tests/Unit/CalculationRequestTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+
+final class CalculationRequestTest extends TestCase
+{
+    public function testForwardFactoryCreatesRequest(): void
+    {
+        $request = CalculationRequest::forward('foo', '10.123', ['bar' => 'baz']);
+
+        self::assertSame('foo', $request->getStrategyName());
+        self::assertSame('10.123', $request->getAmount());
+        self::assertSame(CalculationDirection::FORWARD, $request->getDirection());
+        self::assertSame(['bar' => 'baz'], $request->getContext());
+    }
+
+    public function testBackwardFactoryCreatesRequest(): void
+    {
+        $request = CalculationRequest::backward('bar', '99');
+
+        self::assertSame('bar', $request->getStrategyName());
+        self::assertSame('99', $request->getAmount());
+        self::assertSame(CalculationDirection::BACKWARD, $request->getDirection());
+        self::assertSame([], $request->getContext());
+    }
+
+    public function testEmptyStrategyNameIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The strategy name must not be empty.');
+
+        CalculationRequest::forward('   ', '10');
+    }
+
+    public function testInvalidAmountIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The provided amount "ten" is not a valid numeric string.');
+
+        CalculationRequest::forward('foo', 'ten');
+    }
+
+    public function testWithAmountClonesRequestAndValidates(): void
+    {
+        $original = CalculationRequest::forward('foo', '10');
+        $updated = $original->withAmount('15.5');
+
+        self::assertNotSame($original, $updated);
+        self::assertSame('15.5', $updated->getAmount());
+        self::assertSame($original->getContext(), $updated->getContext());
+
+        $this->expectException(ValidationException::class);
+        $original->withAmount('invalid');
+    }
+
+    public function testWithContextClonesRequest(): void
+    {
+        $original = CalculationRequest::backward('bar', '20');
+        $updated = $original->withContext(['foo' => 'bar']);
+
+        self::assertNotSame($original, $updated);
+        self::assertSame(['foo' => 'bar'], $updated->getContext());
+        self::assertSame('20', $updated->getAmount());
+        self::assertSame($original->getDirection(), $updated->getDirection());
+    }
+}

--- a/tests/Unit/CalculationResultTest.php
+++ b/tests/Unit/CalculationResultTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+final class CalculationResultTest extends TestCase
+{
+    public function testResultExposesProvidedData(): void
+    {
+        $result = new CalculationResult('10', '2', '12', CalculationDirection::FORWARD, ['foo' => 'bar']);
+
+        self::assertSame('10', $result->getBaseAmount());
+        self::assertSame('2', $result->getFeeAmount());
+        self::assertSame('12', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::FORWARD, $result->getDirection());
+        self::assertSame(['foo' => 'bar'], $result->getContext());
+    }
+
+    public function testWithMethodsCloneResult(): void
+    {
+        $result = new CalculationResult('10', '1', '11', CalculationDirection::BACKWARD);
+        $withAmounts = $result->withAmounts('20', '2', '22');
+        $withContext = $result->withContext(['bar' => 'baz']);
+
+        self::assertNotSame($result, $withAmounts);
+        self::assertSame('20', $withAmounts->getBaseAmount());
+        self::assertSame('2', $withAmounts->getFeeAmount());
+        self::assertSame('22', $withAmounts->getTotalAmount());
+        self::assertSame($result->getDirection(), $withAmounts->getDirection());
+
+        self::assertNotSame($result, $withContext);
+        self::assertSame(['bar' => 'baz'], $withContext->getContext());
+        self::assertSame('10', $withContext->getBaseAmount());
+        self::assertSame($result->getDirection(), $withContext->getDirection());
+    }
+}

--- a/tests/Unit/FeeCalculationChainTest.php
+++ b/tests/Unit/FeeCalculationChainTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainRequest;
+use SomeWork\FeeCalculator\Contracts\Chain\CalculationChainStep;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Enum\ChainResultSelection;
+use SomeWork\FeeCalculator\Enum\ChainStepInputSource;
+use InvalidArgumentException;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+use SomeWork\FeeCalculator\FeeCalculationChain;
+use SomeWork\FeeCalculator\FeeCalculator;
+use SomeWork\FeeCalculator\Registry\StrategyRegistry;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+
+final class FeeCalculationChainTest extends TestCase
+{
+    public function testCalculatesSequentialSteps(): void
+    {
+        $registry = new StrategyRegistry([
+            new PercentageFeeStrategy(),
+            new FixedFeeStrategy(),
+        ]);
+
+        $calculator = new FeeCalculator($registry, 4);
+        $chain = new FeeCalculationChain($calculator);
+
+        $request = new CalculationChainRequest(
+            '100',
+            new CalculationChainStep(
+                'conversion',
+                'percentage',
+                CalculationDirection::FORWARD,
+                ChainStepInputSource::INITIAL,
+                ChainResultSelection::TOTAL,
+                [
+                    'fee_percent' => '0.015',
+                ]
+            ),
+            new CalculationChainStep(
+                'withdrawal',
+                'fixed',
+                CalculationDirection::FORWARD,
+                ChainStepInputSource::PREVIOUS_OUTPUT,
+                ChainResultSelection::TOTAL,
+                [
+                    'fee_fix' => '2.5',
+                ]
+            )
+        );
+
+        $result = $chain->calculate($request);
+
+        self::assertSame('100.0000', $result->getInitialAmount());
+        self::assertSame('104.0000', $result->getFinalAmount());
+
+        $steps = $result->getSteps();
+        self::assertCount(2, $steps);
+
+        $first = $steps[0];
+        self::assertSame('conversion', $first->getStep()->getIdentifier());
+        self::assertSame('101.5000', $first->getOutputAmount());
+        self::assertSame('0.015', $first->getResult()->getContext()['fee_percent']);
+
+        $second = $steps[1];
+        self::assertSame('withdrawal', $second->getStep()->getIdentifier());
+        self::assertSame('104.0000', $second->getOutputAmount());
+        self::assertSame('2.5000', $second->getResult()->getContext()['fee_fix']);
+
+        self::assertSame($second, $result->getLastStepResult());
+    }
+
+    public function testThrowsWhenPreviousOutputMissing(): void
+    {
+        $chain = new FeeCalculationChain(new FeeCalculator(new StrategyRegistry(), 2));
+        $request = $this->createBrokenChainRequest('10', new CalculationChainStep(
+            'broken',
+            'unused',
+            CalculationDirection::FORWARD,
+            ChainStepInputSource::PREVIOUS_OUTPUT
+        ));
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Step #1 expects an output value from the previous step, but none is available.');
+
+        $chain->calculate($request);
+    }
+
+    public function testRequirePreviousResultGuardsAgainstMissingData(): void
+    {
+        $chain = new FeeCalculationChain(new FeeCalculator(new StrategyRegistry(), 2));
+        $request = $this->createBrokenChainRequest('10');
+        $step = new CalculationChainStep(
+            'second',
+            'unused',
+            CalculationDirection::FORWARD,
+            ChainStepInputSource::PREVIOUS_TOTAL
+        );
+
+        $reflection = new ReflectionClass(FeeCalculationChain::class);
+        $method = $reflection->getMethod('resolveInputAmount');
+        $method->setAccessible(true);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Step #2 expects a previous result for source "PREVIOUS_TOTAL", but none is available.');
+
+        $method->invoke($chain, $request, $step, null, null, 1);
+    }
+
+    private function createBrokenChainRequest(string $initialAmount, CalculationChainStep ...$steps): CalculationChainRequest
+    {
+        $reflection = new ReflectionClass(CalculationChainRequest::class);
+        /** @var CalculationChainRequest $request */
+        $request = $reflection->newInstanceWithoutConstructor();
+
+        $initialProperty = $reflection->getProperty('initialAmount');
+        $initialProperty->setAccessible(true);
+        $initialProperty->setValue($request, $initialAmount);
+
+        $stepsProperty = $reflection->getProperty('steps');
+        $stepsProperty->setAccessible(true);
+        $stepsProperty->setValue($request, $steps);
+
+        return $request;
+    }
+}
+
+final class PercentageFeeStrategy implements FeeStrategyInterface
+{
+    public function getName(): string
+    {
+        return 'percentage';
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        return $direction === CalculationDirection::FORWARD;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        $base = bcadd($request->getAmount(), '0', 4);
+        $contextPercent = $request->getContext()['fee_percent'] ?? '0';
+
+        if (!is_string($contextPercent)) {
+            throw new InvalidArgumentException('fee_percent must be provided as a string');
+        }
+
+        $percent = $contextPercent;
+        $fee = bcmul($base, $percent, 6);
+        $normalizedFee = bcadd($fee, '0', 4);
+        $total = bcadd($base, $normalizedFee, 4);
+
+        return new CalculationResult(
+            $base,
+            $normalizedFee,
+            $total,
+            CalculationDirection::FORWARD,
+            [
+                'fee_percent' => $percent,
+            ]
+        );
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        throw new \LogicException('Backward calculation is not supported.');
+    }
+}
+
+final class FixedFeeStrategy implements FeeStrategyInterface
+{
+    public function getName(): string
+    {
+        return 'fixed';
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        return $direction === CalculationDirection::FORWARD;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        $base = bcadd($request->getAmount(), '0', 4);
+        $contextFix = $request->getContext()['fee_fix'] ?? '0';
+
+        if (!is_string($contextFix)) {
+            throw new InvalidArgumentException('fee_fix must be provided as a string');
+        }
+
+        $feeFix = $contextFix;
+        $normalizedFee = bcadd($feeFix, '0', 4);
+        $total = bcadd($base, $normalizedFee, 4);
+
+        return new CalculationResult(
+            $base,
+            $normalizedFee,
+            $total,
+            CalculationDirection::FORWARD,
+            [
+                'fee_fix' => $normalizedFee,
+            ]
+        );
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        throw new \LogicException('Backward calculation is not supported.');
+    }
+}

--- a/tests/Unit/FeeCalculatorTest.php
+++ b/tests/Unit/FeeCalculatorTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use Closure;
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Exception\UnsupportedCalculationDirectionException;
+use SomeWork\FeeCalculator\Exception\ValidationException;
+use SomeWork\FeeCalculator\FeeCalculator;
+use SomeWork\FeeCalculator\Registry\StrategyRegistry;
+
+final class FeeCalculatorTest extends TestCase
+{
+    public function testForwardCalculationNormalizesAmounts(): void
+    {
+        $receivedRequest = null;
+        $strategy = $this->createStrategy(
+            'percentage',
+            supportsForward: true,
+            supportsBackward: true,
+            forward: function (CalculationRequest $request) use (&$receivedRequest): CalculationResult {
+                $receivedRequest = $request;
+
+                return new CalculationResult(
+                    '10.129',
+                    '0.505',
+                    '10.634',
+                    CalculationDirection::FORWARD
+                );
+            },
+            backward: fn (CalculationRequest $request): CalculationResult => throw new \LogicException('Should not be called'),
+        );
+
+        $registry = new StrategyRegistry([$strategy]);
+        $calculator = new FeeCalculator($registry, 2);
+
+        $result = $calculator->calculate(CalculationRequest::forward('percentage', '10.125'));
+
+        self::assertInstanceOf(CalculationRequest::class, $receivedRequest);
+        self::assertSame('10.12', $receivedRequest->getAmount(), 'Request amount should be normalized.');
+
+        self::assertSame('10.12', $result->getBaseAmount());
+        self::assertSame('0.50', $result->getFeeAmount());
+        self::assertSame('10.63', $result->getTotalAmount());
+    }
+
+    public function testBackwardCalculationPathIsUsed(): void
+    {
+        $strategy = $this->createStrategy(
+            'flat',
+            supportsForward: true,
+            supportsBackward: true,
+            forward: fn (CalculationRequest $request): CalculationResult => throw new \LogicException('Should not be called'),
+            backward: fn (CalculationRequest $request): CalculationResult => new CalculationResult(
+                $request->getAmount(),
+                '1',
+                bcadd($request->getAmount(), '1', 4),
+                CalculationDirection::BACKWARD
+            )
+        );
+
+        $registry = new StrategyRegistry([$strategy]);
+        $calculator = new FeeCalculator($registry, 3);
+
+        $result = $calculator->calculate(CalculationRequest::backward('flat', '20.5'));
+
+        self::assertSame('20.500', $result->getBaseAmount());
+        self::assertSame('1.000', $result->getFeeAmount());
+        self::assertSame('21.500', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::BACKWARD, $result->getDirection());
+    }
+
+    public function testThrowsWhenStrategyDoesNotSupportDirection(): void
+    {
+        $strategy = $this->createStrategy(
+            'unsupported',
+            supportsForward: false,
+            supportsBackward: true,
+            forward: fn (CalculationRequest $request): CalculationResult => throw new \LogicException('Should not be called'),
+            backward: fn (CalculationRequest $request): CalculationResult => new CalculationResult('0', '0', '0', CalculationDirection::BACKWARD)
+        );
+
+        $registry = new StrategyRegistry([$strategy]);
+        $calculator = new FeeCalculator($registry);
+
+        $this->expectException(UnsupportedCalculationDirectionException::class);
+        $this->expectExceptionMessage('Strategy "unsupported" does not support "forward" calculations.');
+
+        $calculator->calculate(CalculationRequest::forward('unsupported', '10'));
+    }
+
+    public function testThrowsWhenStrategyReturnsInvalidAmounts(): void
+    {
+        $strategy = $this->createStrategy(
+            'broken',
+            supportsForward: true,
+            supportsBackward: true,
+            forward: fn (CalculationRequest $request): CalculationResult => new CalculationResult(
+                'ten',
+                '1',
+                '11',
+                CalculationDirection::FORWARD
+            ),
+            backward: fn (CalculationRequest $request): CalculationResult => new CalculationResult('0', '0', '0', CalculationDirection::BACKWARD)
+        );
+
+        $registry = new StrategyRegistry([$strategy]);
+        $calculator = new FeeCalculator($registry);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The provided amount "ten" is not a valid numeric string.');
+
+        $calculator->calculate(CalculationRequest::forward('broken', '10'));
+    }
+
+    public function testScaleMustBeNonNegative(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('The scale "-1" must be greater than or equal to zero.');
+
+        new FeeCalculator(new StrategyRegistry(), -1);
+    }
+
+    private function createStrategy(
+        string $name,
+        bool $supportsForward,
+        bool $supportsBackward,
+        Closure $forward,
+        Closure $backward
+    ): FeeStrategyInterface {
+        return new class($name, $supportsForward, $supportsBackward, $forward, $backward) implements FeeStrategyInterface {
+            public function __construct(
+                private readonly string $name,
+                private readonly bool $supportsForward,
+                private readonly bool $supportsBackward,
+                private readonly Closure $forward,
+                private readonly Closure $backward
+            ) {
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function supportsDirection(CalculationDirection $direction): bool
+            {
+                return match ($direction) {
+                    CalculationDirection::FORWARD => $this->supportsForward,
+                    CalculationDirection::BACKWARD => $this->supportsBackward,
+                };
+            }
+
+            public function calculateForward(CalculationRequest $request): CalculationResult
+            {
+                return ($this->forward)($request);
+            }
+
+            public function calculateBackward(CalculationRequest $request): CalculationResult
+            {
+                return ($this->backward)($request);
+            }
+        };
+    }
+}

--- a/tests/Unit/StrategyRegistryTest.php
+++ b/tests/Unit/StrategyRegistryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit;
+
+use ArrayIterator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Exception\StrategyNotFoundException;
+use SomeWork\FeeCalculator\Registry\StrategyRegistry;
+
+final class StrategyRegistryTest extends TestCase
+{
+    public function testConstructingWithIterableRegistersStrategies(): void
+    {
+        $strategy = $this->createStrategyMock('foo');
+
+        $registry = new StrategyRegistry(new ArrayIterator([$strategy]));
+
+        self::assertTrue($registry->has('foo'));
+        self::assertSame(['foo' => $strategy], $registry->all());
+    }
+
+    public function testRegisterAddsStrategy(): void
+    {
+        $strategy = $this->createStrategyMock('bar');
+
+        $registry = new StrategyRegistry();
+        $registry->register($strategy);
+
+        self::assertTrue($registry->has('bar'));
+        self::assertSame($strategy, $registry->get('bar'));
+    }
+
+    public function testGetThrowsWhenStrategyMissing(): void
+    {
+        $registry = new StrategyRegistry();
+
+        $this->expectException(StrategyNotFoundException::class);
+        $this->expectExceptionMessage('No fee strategy registered with the name "missing".');
+
+        $registry->get('missing');
+    }
+
+    /**
+     * @return FeeStrategyInterface&MockObject
+     */
+    private function createStrategyMock(string $name)
+    {
+        $strategy = $this->createMock(FeeStrategyInterface::class);
+        $strategy->method('getName')->willReturn($name);
+
+        return $strategy;
+    }
+}


### PR DESCRIPTION
## Summary
- update the `test-coverage` Composer script to enable Xdebug when present and fall back to plain test execution when no driver is loaded
- normalize chain requests to operate on a strictly indexed list of steps during validation
- guard the fee strategy test doubles against non-string context values to satisfy static analysis

## Testing
- composer test
- composer test-coverage
- composer check

------
https://chatgpt.com/codex/tasks/task_e_68dbc6955ac88320a92cfc11cbe08cd1