### PR TITLE
Add processor fee strategies and research documentation

### DIFF
--- a/docs/strategy-research.md
+++ b/docs/strategy-research.md
@@ -1,0 +1,104 @@
+# Strategy Research: Processor Fee Structures
+
+This research surveys publicly documented fee structures from major payment providers to inform reusable fee strategies. Formulas below are expressed with variables:
+
+- `B` – base amount (customer-facing price or send amount).
+- `F` – fee amount produced by the strategy.
+- `T` – total amount (amount collected from payer or total debit).
+- `r` – percentage rate expressed as decimal (e.g., 2.9% ⇒ 0.029).
+- `f` – fixed fee amount.
+
+Unless noted otherwise, forward direction means **compute fees from a known base amount** (solve `F` and `T` given `B`). Backward direction means **solve the required base amount given a target total** (`T` known, solve `B` and `F`).
+
+## Stripe
+
+| Strategy | Formula | Typical Use Case | Direction Notes | Source |
+| --- | --- | --- | --- | --- |
+| Standard U.S. card processing | `F = B × 0.029 + 0.30`, `T = B + F`. Backward: `B = (T - 0.30) ÷ 1.029`. | Domestic Visa/Mastercard/AmEx acceptance in the United States. | Supports forward/backward; backward fails if `T < 0.30`. | [Stripe Pricing – Card payments](https://stripe.com/pricing)【1】 |
+| International surcharge | `F = B × 0.015`, `T = B + F`. Backward: `B = T ÷ 1.015`. | Additional fee when the card is issued outside the merchant’s country. | Applies only when international card detected; forward/backward supported. | [Stripe Pricing – International cards](https://stripe.com/pricing)【1】 |
+| Currency conversion (optional extension) | `F = B × 0.01` layered on top of above. | When currency conversion to customer currency is enabled. | Use via separate percentage-only strategy; direction same as surcharge. | [Stripe Pricing – Currency conversion](https://stripe.com/pricing)【1】 |
+
+## PayPal
+
+| Strategy | Formula | Typical Use Case | Direction Notes | Source |
+| --- | --- | --- | --- | --- |
+| Commercial transaction (U.S.) | `F = B × (0.0349 + r_{extra}) + (0.49 + f_{extra})`, `T = B + F`. Backward: `B = (T - 0.49 - f_{extra}) ÷ (1 + 0.0349 + r_{extra})`. | Online card/PayPal wallet checkout for U.S. merchants. Extra percentages cover cross-border (1.5%) or currency conversion surcharges. | Forward/backward supported when total exceeds fixed fee sum. Configure `r_{extra}` and `f_{extra}` for cross-border and flat add-ons. | [PayPal Merchant Fees](https://www.paypal.com/us/webapps/mpp/merchant-fees)【2】 |
+
+## Adyen (Interchange++)
+
+| Strategy | Formula | Typical Use Case | Direction Notes | Source |
+| --- | --- | --- | --- | --- |
+| Interchange++ breakdown | `F = B × (r_{interchange} + r_{scheme} + r_{markup}) + (f_{interchange} + f_{scheme} + f_{markup})`, `T = B + F`. Backward: `B = (T - Σf) ÷ (1 + Σr)`. | Card acquiring on Adyen’s Interchange++ pricing where interchange, scheme, and Adyen markup are itemized. | Requires per-transaction interchange & scheme inputs (from card/bin tables). Supports forward/backward when `T ≥ Σf`. | [Adyen Pricing – Interchange++](https://www.adyen.com/pricing)【3】 |
+
+**Direction requirements:** Interchange rates vary by card type and region; the strategy expects context values such as `interchange_percentage`, `scheme_percentage`, and markup values. Backward calculations require the same context used for forward runs.
+
+## Wise (Remittance)
+
+| Strategy | Formula | Typical Use Case | Direction Notes | Source |
+| --- | --- | --- | --- | --- |
+| Variable + fixed transfer fee | `F = B × (r_{base} + r_{adj}) + (f_{base} + f_{adj})`, `T = B + F`. Backward: `B = (T - f_{base} - f_{adj}) ÷ (1 + r_{base} + r_{adj})`. | International money transfers where Wise publishes route-specific variable and fixed fees. Context supplies actual rates per currency corridor. | Supports forward/backward when totals exceed fixed sums. Use context overrides to inject corridor data obtained via Wise pricing API. | [Wise Fees and Pricing](https://wise.com/help/articles/2932695/fees-and-pricing)【4】 |
+
+## Card Scheme Components
+
+Card schemes publish assessment and cross-border fees that flow into acquirer pricing. For example, Visa U.S. assessment is 0.13% on credit volume with cross-border surcharges of 1.00%–1.80% depending on region.【5】 These values feed into interchange or scheme components in the Adyen strategy and should be mapped into `scheme_percentage`/`scheme_fixed` fields. Merchants must update these values when card networks revise schedules.
+
+[5]: https://usa.visa.com/dam/VCOM/download/merchants/visa-merchant-data-standards-manual.pdf
+
+## Strategy Implementations
+
+The following strategies implement `FeeStrategyInterface` with BC Math arithmetic:
+
+- `StripeStandardCardStrategy` – domestic flat + percentage fee. Backward uses `B = (T - f) ÷ (1 + r)` to solve net amount.
+- `StripeInternationalSurchargeStrategy` – percentage-only surcharge stacked onto domestic pricing.
+- `PayPalCommercialTransactionStrategy` – allows context-driven surcharges for cross-border, currency conversion, and additional flat fees.
+- `AdyenInterchangePlusPlusStrategy` – aggregates interchange, scheme, and markup components supplied in context.
+- `WiseTransferFeeStrategy` – models Wise’s variable + fixed corridor pricing with optional adjustments.
+- `CompositeFeeStrategy` – orchestrates multiple strategies deterministically, using binary search for backward calculations when layered fees are present.
+
+## Configuration Examples
+
+### Standalone Strategies
+
+```php
+use SomeWork\FeeCalculator\Strategy\StripeStandardCardStrategy;
+use SomeWork\FeeCalculator\Strategy\StripeInternationalSurchargeStrategy;
+
+$stripeStandard = new StripeStandardCardStrategy();
+$stripeInternational = new StripeInternationalSurchargeStrategy(
+    'stripe.intl_eu_surcharge',
+    '0.02' // 2% surcharge for a specific market
+);
+```
+
+### Composite Strategy with Guardrails
+
+```php
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Strategy\CompositeFeeStrategy;
+use SomeWork\FeeCalculator\Strategy\StripeStandardCardStrategy;
+use SomeWork\FeeCalculator\Strategy\StripeInternationalSurchargeStrategy;
+
+$composite = new CompositeFeeStrategy([
+    new StripeStandardCardStrategy(),
+    new StripeInternationalSurchargeStrategy(),
+], 'stripe.full_stack');
+
+$request = CalculationRequest::forward('stripe.full_stack', '100.00');
+$result = $composite->calculateForward($request);
+```
+
+**Guardrails and precedence rules:**
+
+1. Order matters—strategies are evaluated sequentially in the array supplied to `CompositeFeeStrategy`; each strategy receives the original base amount, and composite totals sum all child fees.
+2. Each child strategy **must** support the requested direction; otherwise `UnsupportedCalculationDirectionException` is thrown.
+3. Backward calculations validate the requested total against the minimal achievable total (sum of fixed fees at zero base). If the total is too low, an `InvalidArgumentException` is raised.
+4. Component-specific context should be nested under `['components' => ['strategy.name' => [...]]]`. A shared context block (`['shared' => [...]]`) can distribute common metadata to every child.
+5. Precision defaults to scale `8`; adjust the constructor argument for finer tolerance when solving backward totals.
+
+These patterns enable layered fee modelling for realistic processor setups while maintaining explicit control over directionality and context injection.
+
+
+[1]: https://stripe.com/pricing
+[2]: https://www.paypal.com/us/webapps/mpp/merchant-fees
+[3]: https://www.adyen.com/pricing
+[4]: https://wise.com/help/articles/2932695/fees-and-pricing

--- a/src/Strategy/AbstractFeeStrategy.php
+++ b/src/Strategy/AbstractFeeStrategy.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Strategy;
+
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Exception\UnsupportedCalculationDirectionException;
+
+abstract class AbstractFeeStrategy
+{
+    private int $scale;
+
+    private int $calculationScale;
+
+    public function __construct(int $scale = 8)
+    {
+        $this->scale = max(0, $scale);
+        $this->calculationScale = $this->scale + 4;
+    }
+
+    public function getScale(): int
+    {
+        return $this->scale;
+    }
+
+    protected function getCalculationScale(): int
+    {
+        return $this->calculationScale;
+    }
+
+    protected function normalize(string $value): string
+    {
+        if (str_contains($value, '.')) {
+            $value = rtrim(rtrim($value, '0'), '.');
+        }
+
+        return $value === '' ? '0' : $value;
+    }
+
+    protected function add(string $left, string $right): string
+    {
+        return $this->normalize(bcadd($left, $right, $this->calculationScale));
+    }
+
+    protected function subtract(string $left, string $right): string
+    {
+        return $this->normalize(bcsub($left, $right, $this->calculationScale));
+    }
+
+    protected function multiply(string $left, string $right): string
+    {
+        return $this->normalize(bcmul($left, $right, $this->calculationScale));
+    }
+
+    protected function divide(string $left, string $right): string
+    {
+        return $this->normalize(bcdiv($left, $right, $this->calculationScale));
+    }
+
+    protected function compare(string $left, string $right): int
+    {
+        return bccomp($left, $right, $this->calculationScale);
+    }
+
+    protected function absolute(string $value): string
+    {
+        if (str_starts_with($value, '-')) {
+            return substr($value, 1) ?: '0';
+        }
+
+        return $value;
+    }
+
+    protected function ensureDirectionSupported(
+        CalculationDirection $direction,
+        bool $isSupported,
+        string $strategyName
+    ): void {
+        if (!$isSupported) {
+            throw UnsupportedCalculationDirectionException::forStrategy($strategyName, $direction);
+        }
+    }
+
+    protected function castNumericString(mixed $value, string $key): string
+    {
+        if (is_int($value) || is_float($value)) {
+            $value = (string) $value;
+        }
+
+        if (!is_string($value) || !preg_match('/^-?\d+(?:\.\d+)?$/', $value)) {
+            throw new \InvalidArgumentException(sprintf('Context value "%s" must be a numeric string.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     * @return array<string, mixed>
+     */
+    protected function mergeComponentContext(array $context, array $componentContext): array
+    {
+        return array_replace($context, $componentContext);
+    }
+
+    protected function createForwardResult(
+        CalculationRequest $request,
+        string $baseAmount,
+        string $feeAmount,
+        string $totalAmount,
+        array $context = []
+    ): \SomeWork\FeeCalculator\Contracts\CalculationResult {
+        return new \SomeWork\FeeCalculator\Contracts\CalculationResult(
+            $this->normalize($baseAmount),
+            $this->normalize($feeAmount),
+            $this->normalize($totalAmount),
+            CalculationDirection::FORWARD,
+            $this->mergeComponentContext($request->getContext(), $context)
+        );
+    }
+
+    protected function createBackwardResult(
+        CalculationRequest $request,
+        string $baseAmount,
+        string $feeAmount,
+        string $totalAmount,
+        array $context = []
+    ): \SomeWork\FeeCalculator\Contracts\CalculationResult {
+        return new \SomeWork\FeeCalculator\Contracts\CalculationResult(
+            $this->normalize($baseAmount),
+            $this->normalize($feeAmount),
+            $this->normalize($totalAmount),
+            CalculationDirection::BACKWARD,
+            $this->mergeComponentContext($request->getContext(), $context)
+        );
+    }
+}

--- a/src/Strategy/AdyenInterchangePlusPlusStrategy.php
+++ b/src/Strategy/AdyenInterchangePlusPlusStrategy.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Strategy;
+
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+final class AdyenInterchangePlusPlusStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
+{
+    private const string DEFAULT_NAME = 'adyen.interchange_plus_plus';
+
+    private string $name;
+
+    public function __construct(string $name = self::DEFAULT_NAME, int $scale = 8)
+    {
+        parent::__construct($scale);
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        return true;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        [$percentageRate, $fixedFee, $meta] = $this->resolveComponents($request);
+        $baseAmount = $request->getAmount();
+        $percentageFee = $this->multiply($baseAmount, $percentageRate);
+        $feeAmount = $this->add($percentageFee, $fixedFee);
+        $totalAmount = $this->add($baseAmount, $feeAmount);
+
+        return $this->createForwardResult($request, $baseAmount, $feeAmount, $totalAmount, $meta);
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        [$percentageRate, $fixedFee, $meta] = $this->resolveComponents($request);
+        $totalAmount = $request->getAmount();
+        $denominator = $this->add('1', $percentageRate);
+        $adjustedTotal = $this->subtract($totalAmount, $fixedFee);
+        $baseAmount = $this->divide($adjustedTotal, $denominator);
+        $percentageFee = $this->multiply($baseAmount, $percentageRate);
+        $feeAmount = $this->add($percentageFee, $fixedFee);
+
+        return $this->createBackwardResult($request, $baseAmount, $feeAmount, $totalAmount, $meta);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: array<string, mixed>}
+     */
+    private function resolveComponents(CalculationRequest $request): array
+    {
+        $context = $request->getContext();
+
+        $interchangePercentage = isset($context['interchange_percentage'])
+            ? $this->castNumericString($context['interchange_percentage'], 'interchange_percentage')
+            : '0';
+        $interchangeFixed = isset($context['interchange_fixed'])
+            ? $this->castNumericString($context['interchange_fixed'], 'interchange_fixed')
+            : '0';
+
+        $schemePercentage = isset($context['scheme_percentage'])
+            ? $this->castNumericString($context['scheme_percentage'], 'scheme_percentage')
+            : '0';
+        $schemeFixed = isset($context['scheme_fixed'])
+            ? $this->castNumericString($context['scheme_fixed'], 'scheme_fixed')
+            : '0';
+
+        $markupPercentage = isset($context['markup_percentage'])
+            ? $this->castNumericString($context['markup_percentage'], 'markup_percentage')
+            : '0';
+        $markupFixed = isset($context['markup_fixed'])
+            ? $this->castNumericString($context['markup_fixed'], 'markup_fixed')
+            : '0';
+
+        $effectivePercentage = $this->add($interchangePercentage, $schemePercentage);
+        $effectivePercentage = $this->add($effectivePercentage, $markupPercentage);
+
+        $effectiveFixed = $this->add($interchangeFixed, $schemeFixed);
+        $effectiveFixed = $this->add($effectiveFixed, $markupFixed);
+
+        $components = [
+            'strategy' => $this->name,
+            'interchange_percentage' => $interchangePercentage,
+            'interchange_fixed' => $interchangeFixed,
+            'scheme_percentage' => $schemePercentage,
+            'scheme_fixed' => $schemeFixed,
+            'markup_percentage' => $markupPercentage,
+            'markup_fixed' => $markupFixed,
+            'documentation' => 'https://www.adyen.com/pricing',
+        ];
+
+        return [$effectivePercentage, $effectiveFixed, $components];
+    }
+}

--- a/src/Strategy/CompositeFeeStrategy.php
+++ b/src/Strategy/CompositeFeeStrategy.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Strategy;
+
+use InvalidArgumentException;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+/**
+ * @implements FeeStrategyInterface
+ */
+final class CompositeFeeStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
+{
+    private const string DEFAULT_NAME = 'composite';
+
+    /** @var list<FeeStrategyInterface> */
+    private array $strategies;
+
+    private string $name;
+
+    private int $maxIterations;
+
+    public function __construct(array $strategies, string $name = self::DEFAULT_NAME, int $scale = 8, int $maxIterations = 50)
+    {
+        parent::__construct($scale);
+
+        if ($strategies === []) {
+            throw new InvalidArgumentException('CompositeFeeStrategy requires at least one strategy.');
+        }
+
+        foreach ($strategies as $strategy) {
+            if (!$strategy instanceof FeeStrategyInterface) {
+                throw new InvalidArgumentException('CompositeFeeStrategy expects only FeeStrategyInterface instances.');
+            }
+        }
+
+        $this->strategies = array_values($strategies);
+        $this->name = $name;
+        $this->maxIterations = max(1, $maxIterations);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        foreach ($this->strategies as $strategy) {
+            if (!$strategy->supportsDirection($direction)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        $this->ensureDirectionSupported($request->getDirection(), $this->supportsDirection(CalculationDirection::FORWARD), $this->name);
+
+        [$feeAmount, $totalAmount, $componentResults] = $this->runForward($request->getAmount(), $request->getContext());
+
+        return $this->createForwardResult($request, $request->getAmount(), $feeAmount, $totalAmount, [
+            'strategy' => $this->name,
+            'component_results' => $componentResults,
+        ]);
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        $this->ensureDirectionSupported($request->getDirection(), $this->supportsDirection(CalculationDirection::BACKWARD), $this->name);
+
+        [$baseAmount, $feeAmount, $totalAmount, $componentResults] = $this->solveForBaseAmount(
+            $request->getAmount(),
+            $request->getContext()
+        );
+
+        $resultRequest = $request->withAmount($baseAmount);
+
+        return $this->createBackwardResult($resultRequest, $baseAmount, $feeAmount, $totalAmount, [
+            'strategy' => $this->name,
+            'component_results' => $componentResults,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $requestContext
+     * @return array{0: string, 1: string, 2: array<string, array<string, mixed>>}
+     */
+    private function runForward(string $baseAmount, array $requestContext): array
+    {
+        $totalFee = '0';
+        $componentResults = [];
+
+        foreach ($this->strategies as $strategy) {
+            $childContext = $this->resolveComponentContext($strategy->getName(), $requestContext);
+            $childRequest = CalculationRequest::forward($strategy->getName(), $baseAmount, $childContext);
+            $childResult = $strategy->calculateForward($childRequest);
+            $totalFee = $this->add($totalFee, $childResult->getFeeAmount());
+            $componentResults[$strategy->getName()] = [
+                'base_amount' => $childResult->getBaseAmount(),
+                'fee_amount' => $childResult->getFeeAmount(),
+                'total_amount' => $childResult->getTotalAmount(),
+                'context' => $childResult->getContext(),
+            ];
+        }
+
+        $totalAmount = $this->add($baseAmount, $totalFee);
+
+        return [$totalFee, $totalAmount, $componentResults];
+    }
+
+    /**
+     * @param array<string, mixed> $requestContext
+     * @return array{0: string, 1: string, 2: string, 3: array<string, array<string, mixed>>}
+     */
+    private function solveForBaseAmount(string $targetTotal, array $requestContext): array
+    {
+        [, $minimalTotal] = $this->runForward('0', $requestContext);
+        if ($this->compare($targetTotal, $minimalTotal) < 0) {
+            throw new InvalidArgumentException('Total amount is lower than the minimal possible composite total.');
+        }
+
+        $lower = '0';
+        $upper = $targetTotal;
+        $bestBase = $lower;
+        $bestDifference = $this->absolute($this->subtract($targetTotal, $minimalTotal));
+
+        for ($iteration = 0; $iteration < $this->maxIterations; $iteration++) {
+            $mid = $this->divide($this->add($lower, $upper), '2');
+            [$fee, $total, $components] = $this->runForward($mid, $requestContext);
+            $difference = $this->absolute($this->subtract($total, $targetTotal));
+
+            if ($iteration === 0 || $this->compare($difference, $bestDifference) < 0) {
+                $bestDifference = $difference;
+                $bestBase = $mid;
+            }
+
+            if ($this->compare($difference, $this->tolerance()) <= 0) {
+                break;
+            }
+
+            if ($this->compare($total, $targetTotal) > 0) {
+                $upper = $mid;
+            } else {
+                $lower = $mid;
+            }
+        }
+
+        $bestBase = $this->normalize(bcadd($bestBase, '0', $this->getScale()));
+        [$finalFee, $finalTotal, $finalComponents] = $this->runForward($bestBase, $requestContext);
+
+        return [$bestBase, $finalFee, $finalTotal, $finalComponents];
+    }
+
+    /**
+     * @param array<string, mixed> $requestContext
+     * @return array<string, mixed>
+     */
+    private function resolveComponentContext(string $strategyName, array $requestContext): array
+    {
+        $baseContext = $requestContext;
+        unset($baseContext['components'], $baseContext['shared']);
+
+        $sharedContext = $requestContext['shared'] ?? [];
+        if (!is_array($sharedContext)) {
+            throw new InvalidArgumentException('Composite shared context must be an array.');
+        }
+
+        $componentSpecific = [];
+        if (isset($requestContext['components'])) {
+            if (!is_array($requestContext['components'])) {
+                throw new InvalidArgumentException('Composite components context must be an array keyed by strategy name.');
+            }
+
+            if (isset($requestContext['components'][$strategyName])) {
+                $componentSpecific = $requestContext['components'][$strategyName];
+                if (!is_array($componentSpecific)) {
+                    throw new InvalidArgumentException(sprintf('Component context for "%s" must be an array.', $strategyName));
+                }
+            }
+        }
+
+        return array_replace($baseContext, $sharedContext, $componentSpecific);
+    }
+
+    private function tolerance(): string
+    {
+        $scale = $this->getScale();
+        if ($scale <= 0) {
+            return '1';
+        }
+
+        $denominator = '1' . str_repeat('0', $scale);
+
+        return $this->divide('1', $denominator);
+    }
+}

--- a/src/Strategy/PayPalCommercialTransactionStrategy.php
+++ b/src/Strategy/PayPalCommercialTransactionStrategy.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Strategy;
+
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+final class PayPalCommercialTransactionStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
+{
+    private const string DEFAULT_NAME = 'paypal.commercial_transaction';
+
+    private string $name;
+
+    private string $basePercentageRate;
+
+    private string $fixedFee;
+
+    private string $defaultCrossBorderPercentage;
+
+    public function __construct(
+        string $name = self::DEFAULT_NAME,
+        string $basePercentageRate = '0.0349',
+        string $fixedFee = '0.49',
+        string $defaultCrossBorderPercentage = '0.015',
+        int $scale = 8
+    ) {
+        parent::__construct($scale);
+        $this->name = $name;
+        $this->basePercentageRate = $basePercentageRate;
+        $this->fixedFee = $fixedFee;
+        $this->defaultCrossBorderPercentage = $defaultCrossBorderPercentage;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        return true;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        [$percentageRate, $fixedFee, $meta] = $this->resolveEffectiveRates($request);
+        $baseAmount = $request->getAmount();
+        $percentageFee = $this->multiply($baseAmount, $percentageRate);
+        $feeAmount = $this->add($percentageFee, $fixedFee);
+        $totalAmount = $this->add($baseAmount, $feeAmount);
+
+        return $this->createForwardResult($request, $baseAmount, $feeAmount, $totalAmount, $meta);
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        [$percentageRate, $fixedFee, $meta] = $this->resolveEffectiveRates($request);
+        $totalAmount = $request->getAmount();
+        $denominator = $this->add('1', $percentageRate);
+        $adjustedTotal = $this->subtract($totalAmount, $fixedFee);
+        $baseAmount = $this->divide($adjustedTotal, $denominator);
+        $percentageFee = $this->multiply($baseAmount, $percentageRate);
+        $feeAmount = $this->add($percentageFee, $fixedFee);
+
+        return $this->createBackwardResult($request, $baseAmount, $feeAmount, $totalAmount, $meta);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: array<string, mixed>}
+     */
+    private function resolveEffectiveRates(CalculationRequest $request): array
+    {
+        $context = $request->getContext();
+        $effectivePercentage = $this->basePercentageRate;
+        $components = [
+            'base_percentage_rate' => $this->basePercentageRate,
+        ];
+
+        if (($context['cross_border'] ?? false) === true) {
+            $effectivePercentage = $this->add($effectivePercentage, $this->defaultCrossBorderPercentage);
+            $components['cross_border_percentage'] = $this->defaultCrossBorderPercentage;
+        }
+
+        if (isset($context['additional_percentage'])) {
+            $additionalPercentage = $this->castNumericString($context['additional_percentage'], 'additional_percentage');
+            $effectivePercentage = $this->add($effectivePercentage, $additionalPercentage);
+            $components['additional_percentage'] = $additionalPercentage;
+        }
+
+        if (isset($context['currency_conversion_percentage'])) {
+            $conversionPercentage = $this->castNumericString($context['currency_conversion_percentage'], 'currency_conversion_percentage');
+            $effectivePercentage = $this->add($effectivePercentage, $conversionPercentage);
+            $components['currency_conversion_percentage'] = $conversionPercentage;
+        }
+
+        $effectiveFixed = $this->fixedFee;
+        $components['fixed_fee'] = $this->fixedFee;
+
+        if (isset($context['additional_fixed_fee'])) {
+            $additionalFixed = $this->castNumericString($context['additional_fixed_fee'], 'additional_fixed_fee');
+            $effectiveFixed = $this->add($effectiveFixed, $additionalFixed);
+            $components['additional_fixed_fee'] = $additionalFixed;
+        }
+
+        $components['strategy'] = $this->name;
+        $components['documentation'] = 'https://www.paypal.com/us/webapps/mpp/merchant-fees';
+
+        return [$effectivePercentage, $effectiveFixed, $components];
+    }
+}

--- a/src/Strategy/StripeInternationalSurchargeStrategy.php
+++ b/src/Strategy/StripeInternationalSurchargeStrategy.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Strategy;
+
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+final class StripeInternationalSurchargeStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
+{
+    private const string DEFAULT_NAME = 'stripe.international_surcharge';
+
+    private string $name;
+
+    private string $percentageRate;
+
+    public function __construct(string $name = self::DEFAULT_NAME, string $percentageRate = '0.015', int $scale = 8)
+    {
+        parent::__construct($scale);
+        $this->name = $name;
+        $this->percentageRate = $percentageRate;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        return true;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        $baseAmount = $request->getAmount();
+        $feeAmount = $this->multiply($baseAmount, $this->percentageRate);
+        $totalAmount = $this->add($baseAmount, $feeAmount);
+
+        return $this->createForwardResult($request, $baseAmount, $feeAmount, $totalAmount, [
+            'strategy' => $this->name,
+            'percentage_rate' => $this->percentageRate,
+            'documentation' => 'https://stripe.com/pricing',
+            'description' => 'Applies Stripe international card surcharge.',
+        ]);
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        $totalAmount = $request->getAmount();
+        $denominator = $this->add('1', $this->percentageRate);
+        $baseAmount = $this->divide($totalAmount, $denominator);
+        $feeAmount = $this->subtract($totalAmount, $baseAmount);
+
+        return $this->createBackwardResult($request, $baseAmount, $feeAmount, $totalAmount, [
+            'strategy' => $this->name,
+            'percentage_rate' => $this->percentageRate,
+            'documentation' => 'https://stripe.com/pricing',
+            'description' => 'Applies Stripe international card surcharge.',
+        ]);
+    }
+}

--- a/src/Strategy/StripeStandardCardStrategy.php
+++ b/src/Strategy/StripeStandardCardStrategy.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Strategy;
+
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+final class StripeStandardCardStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
+{
+    private const string DEFAULT_NAME = 'stripe.standard_card';
+
+    private string $name;
+
+    private string $percentageRate;
+
+    private string $fixedFee;
+
+    public function __construct(string $name = self::DEFAULT_NAME, string $percentageRate = '0.029', string $fixedFee = '0.30', int $scale = 8)
+    {
+        parent::__construct($scale);
+        $this->name = $name;
+        $this->percentageRate = $percentageRate;
+        $this->fixedFee = $fixedFee;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        return true;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        $baseAmount = $request->getAmount();
+        $percentageFee = $this->multiply($baseAmount, $this->percentageRate);
+        $feeAmount = $this->add($percentageFee, $this->fixedFee);
+        $totalAmount = $this->add($baseAmount, $feeAmount);
+
+        return $this->createForwardResult($request, $baseAmount, $feeAmount, $totalAmount, [
+            'strategy' => $this->name,
+            'percentage_rate' => $this->percentageRate,
+            'fixed_fee' => $this->fixedFee,
+            'documentation' => 'https://stripe.com/pricing',
+        ]);
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        $this->ensureDirectionSupported($request->getDirection(), $this->supportsDirection($request->getDirection()), $this->name);
+
+        $totalAmount = $request->getAmount();
+        $denominator = $this->add('1', $this->percentageRate);
+        $adjustedTotal = $this->subtract($totalAmount, $this->fixedFee);
+        $baseAmount = $this->divide($adjustedTotal, $denominator);
+        $percentageFee = $this->multiply($baseAmount, $this->percentageRate);
+        $feeAmount = $this->add($percentageFee, $this->fixedFee);
+
+        return $this->createBackwardResult($request, $baseAmount, $feeAmount, $totalAmount, [
+            'strategy' => $this->name,
+            'percentage_rate' => $this->percentageRate,
+            'fixed_fee' => $this->fixedFee,
+            'documentation' => 'https://stripe.com/pricing',
+        ]);
+    }
+}

--- a/src/Strategy/WiseTransferFeeStrategy.php
+++ b/src/Strategy/WiseTransferFeeStrategy.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Strategy;
+
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Contracts\CalculationResult;
+use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+
+final class WiseTransferFeeStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
+{
+    private const string DEFAULT_NAME = 'wise.transfer';
+
+    private string $name;
+
+    private string $defaultVariablePercentage;
+
+    private string $defaultFixedFee;
+
+    public function __construct(
+        string $name = self::DEFAULT_NAME,
+        string $defaultVariablePercentage = '0.0065',
+        string $defaultFixedFee = '0.31',
+        int $scale = 8
+    ) {
+        parent::__construct($scale);
+        $this->name = $name;
+        $this->defaultVariablePercentage = $defaultVariablePercentage;
+        $this->defaultFixedFee = $defaultFixedFee;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function supportsDirection(CalculationDirection $direction): bool
+    {
+        return true;
+    }
+
+    public function calculateForward(CalculationRequest $request): CalculationResult
+    {
+        [$percentageRate, $fixedFee, $meta] = $this->resolveFees($request);
+        $baseAmount = $request->getAmount();
+        $percentageFee = $this->multiply($baseAmount, $percentageRate);
+        $feeAmount = $this->add($percentageFee, $fixedFee);
+        $totalAmount = $this->add($baseAmount, $feeAmount);
+
+        return $this->createForwardResult($request, $baseAmount, $feeAmount, $totalAmount, $meta);
+    }
+
+    public function calculateBackward(CalculationRequest $request): CalculationResult
+    {
+        [$percentageRate, $fixedFee, $meta] = $this->resolveFees($request);
+        $totalAmount = $request->getAmount();
+        $denominator = $this->add('1', $percentageRate);
+        $adjustedTotal = $this->subtract($totalAmount, $fixedFee);
+        $baseAmount = $this->divide($adjustedTotal, $denominator);
+        $percentageFee = $this->multiply($baseAmount, $percentageRate);
+        $feeAmount = $this->add($percentageFee, $fixedFee);
+
+        return $this->createBackwardResult($request, $baseAmount, $feeAmount, $totalAmount, $meta);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: array<string, mixed>}
+     */
+    private function resolveFees(CalculationRequest $request): array
+    {
+        $context = $request->getContext();
+
+        $percentageRate = isset($context['variable_percentage'])
+            ? $this->castNumericString($context['variable_percentage'], 'variable_percentage')
+            : $this->defaultVariablePercentage;
+
+        $fixedFee = isset($context['fixed_fee'])
+            ? $this->castNumericString($context['fixed_fee'], 'fixed_fee')
+            : $this->defaultFixedFee;
+
+        if (isset($context['additional_percentage'])) {
+            $additionalPercentage = $this->castNumericString($context['additional_percentage'], 'additional_percentage');
+            $percentageRate = $this->add($percentageRate, $additionalPercentage);
+        }
+
+        if (isset($context['additional_fixed_fee'])) {
+            $additionalFixed = $this->castNumericString($context['additional_fixed_fee'], 'additional_fixed_fee');
+            $fixedFee = $this->add($fixedFee, $additionalFixed);
+        }
+
+        $components = [
+            'strategy' => $this->name,
+            'variable_percentage' => $percentageRate,
+            'fixed_fee' => $fixedFee,
+            'documentation' => 'https://wise.com/help/articles/2932695/fees-and-pricing',
+        ];
+
+        return [$percentageRate, $fixedFee, $components];
+    }
+}

--- a/tests/Unit/Strategy/AdyenInterchangePlusPlusStrategyTest.php
+++ b/tests/Unit/Strategy/AdyenInterchangePlusPlusStrategyTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Strategy\AdyenInterchangePlusPlusStrategy;
+
+final class AdyenInterchangePlusPlusStrategyTest extends TestCase
+{
+    /** @var array<string, string> */
+    private array $context = [
+        'interchange_percentage' => '0.0085',
+        'interchange_fixed' => '0.05',
+        'scheme_percentage' => '0.0012',
+        'scheme_fixed' => '0.02',
+        'markup_percentage' => '0.001',
+        'markup_fixed' => '0.12',
+    ];
+
+    public function testForwardCalculation(): void
+    {
+        $strategy = new AdyenInterchangePlusPlusStrategy();
+        $request = CalculationRequest::forward($strategy->getName(), '100', $this->context);
+
+        $result = $strategy->calculateForward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('1.26', $result->getFeeAmount());
+        self::assertSame('101.26', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::FORWARD, $result->getDirection());
+    }
+
+    public function testBackwardCalculation(): void
+    {
+        $strategy = new AdyenInterchangePlusPlusStrategy();
+        $request = CalculationRequest::backward($strategy->getName(), '101.26', $this->context);
+
+        $result = $strategy->calculateBackward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('1.26', $result->getFeeAmount());
+        self::assertSame('101.26', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::BACKWARD, $result->getDirection());
+    }
+}

--- a/tests/Unit/Strategy/CompositeFeeStrategyTest.php
+++ b/tests/Unit/Strategy/CompositeFeeStrategyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\Strategy;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Strategy\CompositeFeeStrategy;
+use SomeWork\FeeCalculator\Strategy\StripeInternationalSurchargeStrategy;
+use SomeWork\FeeCalculator\Strategy\StripeStandardCardStrategy;
+
+final class CompositeFeeStrategyTest extends TestCase
+{
+    public function testForwardAggregatesChildStrategies(): void
+    {
+        $strategy = new CompositeFeeStrategy([
+            new StripeStandardCardStrategy(),
+            new StripeInternationalSurchargeStrategy(),
+        ], 'stripe.bundle');
+
+        $request = CalculationRequest::forward('stripe.bundle', '100');
+        $result = $strategy->calculateForward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('4.7', $result->getFeeAmount());
+        self::assertSame('104.7', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::FORWARD, $result->getDirection());
+
+        $componentResults = $result->getContext()['component_results'] ?? [];
+        self::assertIsArray($componentResults);
+        self::assertCount(2, $componentResults);
+        self::assertArrayHasKey('stripe.standard_card', $componentResults);
+        self::assertArrayHasKey('stripe.international_surcharge', $componentResults);
+    }
+
+    public function testBackwardAggregatesChildStrategies(): void
+    {
+        $strategy = new CompositeFeeStrategy([
+            new StripeStandardCardStrategy(),
+            new StripeInternationalSurchargeStrategy(),
+        ], 'stripe.bundle');
+
+        $request = CalculationRequest::backward('stripe.bundle', '104.7');
+        $result = $strategy->calculateBackward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('4.7', $result->getFeeAmount());
+        self::assertSame('104.7', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::BACKWARD, $result->getDirection());
+    }
+
+    public function testBackwardThrowsWhenBelowMinimalTotal(): void
+    {
+        $strategy = new CompositeFeeStrategy([
+            new StripeStandardCardStrategy(),
+            new StripeInternationalSurchargeStrategy(),
+        ], 'stripe.bundle');
+
+        $request = CalculationRequest::backward('stripe.bundle', '0.1');
+
+        $this->expectException(InvalidArgumentException::class);
+        $strategy->calculateBackward($request);
+    }
+}

--- a/tests/Unit/Strategy/PayPalCommercialTransactionStrategyTest.php
+++ b/tests/Unit/Strategy/PayPalCommercialTransactionStrategyTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Strategy\PayPalCommercialTransactionStrategy;
+
+final class PayPalCommercialTransactionStrategyTest extends TestCase
+{
+    public function testForwardCalculationWithAdjustments(): void
+    {
+        $strategy = new PayPalCommercialTransactionStrategy();
+        $request = CalculationRequest::forward($strategy->getName(), '100', [
+            'cross_border' => true,
+            'additional_percentage' => '0.01',
+            'additional_fixed_fee' => '0.10',
+        ]);
+
+        $result = $strategy->calculateForward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('6.58', $result->getFeeAmount());
+        self::assertSame('106.58', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::FORWARD, $result->getDirection());
+    }
+
+    public function testBackwardCalculationWithAdjustments(): void
+    {
+        $strategy = new PayPalCommercialTransactionStrategy();
+        $request = CalculationRequest::backward($strategy->getName(), '106.58', [
+            'cross_border' => true,
+            'additional_percentage' => '0.01',
+            'additional_fixed_fee' => '0.10',
+        ]);
+
+        $result = $strategy->calculateBackward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('6.58', $result->getFeeAmount());
+        self::assertSame('106.58', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::BACKWARD, $result->getDirection());
+    }
+}

--- a/tests/Unit/Strategy/StripeInternationalSurchargeStrategyTest.php
+++ b/tests/Unit/Strategy/StripeInternationalSurchargeStrategyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Strategy\StripeInternationalSurchargeStrategy;
+
+final class StripeInternationalSurchargeStrategyTest extends TestCase
+{
+    public function testForwardCalculation(): void
+    {
+        $strategy = new StripeInternationalSurchargeStrategy();
+        $request = CalculationRequest::forward($strategy->getName(), '100');
+
+        $result = $strategy->calculateForward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('1.5', $result->getFeeAmount());
+        self::assertSame('101.5', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::FORWARD, $result->getDirection());
+    }
+
+    public function testBackwardCalculation(): void
+    {
+        $strategy = new StripeInternationalSurchargeStrategy();
+        $request = CalculationRequest::backward($strategy->getName(), '101.5');
+
+        $result = $strategy->calculateBackward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('1.5', $result->getFeeAmount());
+        self::assertSame('101.5', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::BACKWARD, $result->getDirection());
+    }
+}

--- a/tests/Unit/Strategy/StripeStandardCardStrategyTest.php
+++ b/tests/Unit/Strategy/StripeStandardCardStrategyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Strategy\StripeStandardCardStrategy;
+
+final class StripeStandardCardStrategyTest extends TestCase
+{
+    public function testForwardCalculation(): void
+    {
+        $strategy = new StripeStandardCardStrategy();
+        $request = CalculationRequest::forward($strategy->getName(), '100');
+
+        $result = $strategy->calculateForward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('3.2', $result->getFeeAmount());
+        self::assertSame('103.2', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::FORWARD, $result->getDirection());
+    }
+
+    public function testBackwardCalculation(): void
+    {
+        $strategy = new StripeStandardCardStrategy();
+        $request = CalculationRequest::backward($strategy->getName(), '103.2');
+
+        $result = $strategy->calculateBackward($request);
+
+        self::assertSame('100', $result->getBaseAmount());
+        self::assertSame('3.2', $result->getFeeAmount());
+        self::assertSame('103.2', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::BACKWARD, $result->getDirection());
+    }
+}

--- a/tests/Unit/Strategy/WiseTransferFeeStrategyTest.php
+++ b/tests/Unit/Strategy/WiseTransferFeeStrategyTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\Strategy;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Contracts\CalculationRequest;
+use SomeWork\FeeCalculator\Enum\CalculationDirection;
+use SomeWork\FeeCalculator\Strategy\WiseTransferFeeStrategy;
+
+final class WiseTransferFeeStrategyTest extends TestCase
+{
+    /** @var array<string, string> */
+    private array $context = [
+        'variable_percentage' => '0.008',
+        'fixed_fee' => '0.25',
+        'additional_percentage' => '0.001',
+        'additional_fixed_fee' => '0.05',
+    ];
+
+    public function testForwardCalculation(): void
+    {
+        $strategy = new WiseTransferFeeStrategy();
+        $request = CalculationRequest::forward($strategy->getName(), '200', $this->context);
+
+        $result = $strategy->calculateForward($request);
+
+        self::assertSame('200', $result->getBaseAmount());
+        self::assertSame('2.1', $result->getFeeAmount());
+        self::assertSame('202.1', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::FORWARD, $result->getDirection());
+    }
+
+    public function testBackwardCalculation(): void
+    {
+        $strategy = new WiseTransferFeeStrategy();
+        $request = CalculationRequest::backward($strategy->getName(), '202.1', $this->context);
+
+        $result = $strategy->calculateBackward($request);
+
+        self::assertSame('200', $result->getBaseAmount());
+        self::assertSame('2.1', $result->getFeeAmount());
+        self::assertSame('202.1', $result->getTotalAmount());
+        self::assertSame(CalculationDirection::BACKWARD, $result->getDirection());
+    }
+}


### PR DESCRIPTION
## Summary
- add research documentation cataloguing Stripe, PayPal, Adyen, and Wise fee formulas along with guardrails for composite calculations
- implement dedicated BC Math fee strategies and a composite orchestrator that enforces direction support and minimal-total checks
- cover the new strategies with unit tests for both forward and backward calculations

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68dbf94fae108320ac9caa402397b132