### PR TITLE
Add CI workflow with quality checks and coverage enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - master
-      - '**'
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - '**'
+  pull_request:
+
+jobs:
+  build:
+    name: PHP ${{ matrix.php-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ["8.1", "8.2", "8.3", "8.4"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: xdebug
+          extensions: bcmath
+          tools: composer
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock', '**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php-version }}-composer-
+
+      - name: Validate Composer configuration
+        run: composer validate --strict
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Check coding standards
+        run: composer run -- cs
+
+      - name: Static analysis
+        run: composer run -- analyse
+
+      - name: Run tests
+        run: composer run -- test
+
+      - name: Run tests with coverage
+        run: composer run -- test-coverage
+
+      - name: Coverage regression check
+        run: |
+          if [ ! -f build/coverage/clover.xml ]; then
+            echo "Coverage report not found" >&2
+            exit 1
+          fi
+          php bin/check-coverage.php build/coverage/clover.xml 90
+
+      - name: Mutation testing
+        run: composer run -- mutation
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-php-${{ matrix.php-version }}
+          path: |
+            build/coverage
+            build/infection
+          if-no-files-found: warn
+
+      - name: Security audit
+        run: composer audit --locked

--- a/bin/check-coverage.php
+++ b/bin/check-coverage.php
@@ -1,0 +1,67 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+if ($argc < 3) {
+    fwrite(STDERR, "Usage: php bin/check-coverage.php <clover-file> <min-coverage>\n");
+    exit(1);
+}
+
+[$script, $coverageFile, $thresholdArg] = $argv;
+
+if (!is_file($coverageFile)) {
+    fwrite(STDERR, sprintf('Coverage file "%s" not found.%s', $coverageFile, PHP_EOL));
+    exit(1);
+}
+
+$threshold = (float) $thresholdArg;
+if ($threshold < 0 || $threshold > 100) {
+    fwrite(STDERR, 'Threshold must be between 0 and 100.' . PHP_EOL);
+    exit(1);
+}
+
+$contents = file_get_contents($coverageFile);
+if ($contents === false) {
+    fwrite(STDERR, sprintf('Unable to read coverage file "%s".%s', $coverageFile, PHP_EOL));
+    exit(1);
+}
+
+libxml_use_internal_errors(true);
+$xml = simplexml_load_string($contents);
+if ($xml === false) {
+    fwrite(STDERR, 'Unable to parse Clover coverage report.' . PHP_EOL);
+    foreach (libxml_get_errors() as $error) {
+        fwrite(STDERR, trim($error->message) . PHP_EOL);
+    }
+    exit(1);
+}
+
+$metrics = $xml->xpath('//metrics');
+if ($metrics === false || $metrics === []) {
+    fwrite(STDERR, 'No metrics found in Clover coverage report.' . PHP_EOL);
+    exit(1);
+}
+
+$globalMetrics = $metrics[0];
+$statements = (float) $globalMetrics['statements'];
+$coveredStatements = (float) $globalMetrics['coveredstatements'];
+
+$coverage = $statements > 0.0 ? ($coveredStatements / $statements) * 100.0 : 100.0;
+
+$formattedCoverage = number_format($coverage, 2);
+$formattedThreshold = number_format($threshold, 2);
+
+if ($coverage + 1e-6 < $threshold) {
+    fwrite(
+        STDERR,
+        sprintf(
+            'Coverage regression detected: %.2f%% is below the %.2f%% threshold.%s',
+            $coverage,
+            $threshold,
+            PHP_EOL
+        )
+    );
+    exit(1);
+}
+
+echo sprintf('Coverage OK: %s%% >= %s%%%s', $formattedCoverage, $formattedThreshold, PHP_EOL);

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "somework/fee-calculator",
     "type": "library",
+    "description": "Utilities for calculating various fees",
     "license": "MIT",
     "authors": [
         {
@@ -20,11 +21,17 @@
     "require-dev": {
         "phpunit/phpunit": "^10.5",
         "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-deprecation-rules": "^1.1"
+        "phpstan/phpstan-deprecation-rules": "^1.1",
+        "roave/security-advisories": "dev-latest",
+        "infection/infection": "^0.29",
+        "squizlabs/php_codesniffer": "^3.9",
+        "phpunit/phpcov": "^9.0"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "@php -r \"if (!extension_loaded('xdebug') && !extension_loaded('pcov')) { fwrite(STDERR, 'No code coverage driver available; running without coverage.' . PHP_EOL); passthru('vendor/bin/phpunit', $status); exit($status); } if (extension_loaded('xdebug')) { putenv('XDEBUG_MODE=coverage'); } passthru('vendor/bin/phpunit --coverage-text', $status); exit($status);\"",
+        "test": "vendor/bin/phpunit --no-coverage",
+        "test-coverage": "@php -r \"if (!extension_loaded('xdebug') && !extension_loaded('pcov')) { fwrite(STDERR, 'No code coverage driver available; running without coverage.' . PHP_EOL); passthru('vendor/bin/phpunit --no-coverage', $status); exit($status); } if (!is_dir('build/coverage/xml')) { mkdir('build/coverage/xml', 0777, true); } if (!is_dir('build/coverage')) { mkdir('build/coverage', 0777, true); } if (extension_loaded('xdebug')) { putenv('XDEBUG_MODE=coverage'); } passthru('vendor/bin/phpunit --coverage-text=build/coverage/coverage.txt --coverage-clover build/coverage/clover.xml --coverage-xml build/coverage/xml --log-junit build/coverage/junit.xml', $status); exit($status);\"",
         "analyse": [
             "@phpstan",
             "@phpstan-deprecation"
@@ -34,6 +41,13 @@
             "@test"
         ],
         "phpstan": "vendor/bin/phpstan analyse --configuration=phpstan.neon.dist",
-        "phpstan-deprecation": "vendor/bin/phpstan analyse --configuration=phpstan-deprecation.neon"
+        "phpstan-deprecation": "vendor/bin/phpstan analyse --configuration=phpstan-deprecation.neon",
+        "cs": "vendor/bin/phpcs --standard=PSR12 --warning-severity=0 src",
+        "mutation": "@php -r \"if (!extension_loaded('xdebug') && !extension_loaded('pcov') && PHP_SAPI !== 'phpdbg') { fwrite(STDERR, 'Mutation testing skipped: no coverage driver available.' . PHP_EOL); exit(0); } passthru('vendor/bin/infection --threads=max --min-msi=85 --min-covered-msi=85 --ansi', $status); exit($status);\""
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     }
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://infection.github.io/infection/schema.json",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "phpUnit": {
+        "configDir": ".",
+        "customPath": "vendor/bin/phpunit"
+    },
+    "logs": {
+        "text": "build/infection/infection.log",
+        "summary": "build/infection/summary.log"
+    },
+    "tmpDir": "build/infection",
+    "mutators": {
+        "@default": true
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory="build/.phpunit.cache">
   <testsuites>
     <testsuite name="Unit Tests">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <coverage>
+    <report>
+      <clover outputFile="build/coverage/clover.xml"/>
+      <xml outputDirectory="build/coverage/xml"/>
+    </report>
+  </coverage>
   <source>
     <include>
       <directory>src</directory>

--- a/src/Strategy/AbstractFeeStrategy.php
+++ b/src/Strategy/AbstractFeeStrategy.php
@@ -98,6 +98,7 @@ abstract class AbstractFeeStrategy
 
     /**
      * @param array<string, mixed> $context
+     * @param array<string, mixed> $componentContext
      * @return array<string, mixed>
      */
     protected function mergeComponentContext(array $context, array $componentContext): array
@@ -105,6 +106,9 @@ abstract class AbstractFeeStrategy
         return array_replace($context, $componentContext);
     }
 
+    /**
+     * @param array<string, mixed> $context
+     */
     protected function createForwardResult(
         CalculationRequest $request,
         string $baseAmount,
@@ -121,6 +125,9 @@ abstract class AbstractFeeStrategy
         );
     }
 
+    /**
+     * @param array<string, mixed> $context
+     */
     protected function createBackwardResult(
         CalculationRequest $request,
         string $baseAmount,

--- a/src/Strategy/AdyenInterchangePlusPlusStrategy.php
+++ b/src/Strategy/AdyenInterchangePlusPlusStrategy.php
@@ -11,7 +11,7 @@ use SomeWork\FeeCalculator\Enum\CalculationDirection;
 
 final class AdyenInterchangePlusPlusStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
 {
-    private const string DEFAULT_NAME = 'adyen.interchange_plus_plus';
+    private const DEFAULT_NAME = 'adyen.interchange_plus_plus';
 
     private string $name;
 

--- a/src/Strategy/CompositeFeeStrategy.php
+++ b/src/Strategy/CompositeFeeStrategy.php
@@ -12,7 +12,7 @@ use SomeWork\FeeCalculator\Enum\CalculationDirection;
 
 final class CompositeFeeStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
 {
-    private const string DEFAULT_NAME = 'composite';
+    private const DEFAULT_NAME = 'composite';
 
     /** @var list<FeeStrategyInterface> */
     private array $strategies;

--- a/src/Strategy/CompositeFeeStrategy.php
+++ b/src/Strategy/CompositeFeeStrategy.php
@@ -10,9 +10,6 @@ use SomeWork\FeeCalculator\Contracts\CalculationResult;
 use SomeWork\FeeCalculator\Contracts\FeeStrategyInterface;
 use SomeWork\FeeCalculator\Enum\CalculationDirection;
 
-/**
- * @implements FeeStrategyInterface
- */
 final class CompositeFeeStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
 {
     private const string DEFAULT_NAME = 'composite';
@@ -24,6 +21,9 @@ final class CompositeFeeStrategy extends AbstractFeeStrategy implements FeeStrat
 
     private int $maxIterations;
 
+    /**
+     * @param list<FeeStrategyInterface> $strategies
+     */
     public function __construct(array $strategies, string $name = self::DEFAULT_NAME, int $scale = 8, int $maxIterations = 50)
     {
         parent::__construct($scale);

--- a/src/Strategy/PayPalCommercialTransactionStrategy.php
+++ b/src/Strategy/PayPalCommercialTransactionStrategy.php
@@ -11,7 +11,7 @@ use SomeWork\FeeCalculator\Enum\CalculationDirection;
 
 final class PayPalCommercialTransactionStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
 {
-    private const string DEFAULT_NAME = 'paypal.commercial_transaction';
+    private const DEFAULT_NAME = 'paypal.commercial_transaction';
 
     private string $name;
 

--- a/src/Strategy/StripeInternationalSurchargeStrategy.php
+++ b/src/Strategy/StripeInternationalSurchargeStrategy.php
@@ -11,7 +11,7 @@ use SomeWork\FeeCalculator\Enum\CalculationDirection;
 
 final class StripeInternationalSurchargeStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
 {
-    private const string DEFAULT_NAME = 'stripe.international_surcharge';
+    private const DEFAULT_NAME = 'stripe.international_surcharge';
 
     private string $name;
 

--- a/src/Strategy/StripeStandardCardStrategy.php
+++ b/src/Strategy/StripeStandardCardStrategy.php
@@ -11,7 +11,7 @@ use SomeWork\FeeCalculator\Enum\CalculationDirection;
 
 final class StripeStandardCardStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
 {
-    private const string DEFAULT_NAME = 'stripe.standard_card';
+    private const DEFAULT_NAME = 'stripe.standard_card';
 
     private string $name;
 

--- a/src/Strategy/WiseTransferFeeStrategy.php
+++ b/src/Strategy/WiseTransferFeeStrategy.php
@@ -11,7 +11,7 @@ use SomeWork\FeeCalculator\Enum\CalculationDirection;
 
 final class WiseTransferFeeStrategy extends AbstractFeeStrategy implements FeeStrategyInterface
 {
-    private const string DEFAULT_NAME = 'wise.transfer';
+    private const DEFAULT_NAME = 'wise.transfer';
 
     private string $name;
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs coding standards, static analysis, tests, coverage checks, mutation testing, and security audits across PHP 8.1–8.4
- enhance Composer metadata and scripts to support coverage generation, coding standards, and conditional mutation testing
- supply configuration for infection and a coverage gate script while improving phpunit caching and documentation for array shapes

## Testing
- composer validate --strict
- composer install --no-interaction --no-progress --prefer-dist
- composer run -- cs
- composer run -- analyse
- composer run -- test
- composer run -- test-coverage
- composer run -- mutation
- composer audit --locked
- php bin/check-coverage.php build/coverage/clover.xml 90


------
https://chatgpt.com/codex/tasks/task_e_68dbff6df6948320aa99431cb43d87b2