### PR TITLE
Compare amount equality using BC Math

### DIFF
--- a/src/Currency/Currency.php
+++ b/src/Currency/Currency.php
@@ -40,5 +40,4 @@ final class Currency
     {
         return $this->precision;
     }
-
 }

--- a/src/Currency/Currency.php
+++ b/src/Currency/Currency.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Currency;
+
+use InvalidArgumentException;
+
+/**
+ * @psalm-immutable
+ */
+final class Currency
+{
+    private readonly string $code;
+
+    private readonly int $precision;
+
+    public function __construct(string $code, int $precision)
+    {
+        $code = strtoupper($code);
+
+        if ($code === '') {
+            throw new InvalidArgumentException('Currency code cannot be empty.');
+        }
+
+        if ($precision < 0) {
+            throw new InvalidArgumentException('Currency precision cannot be negative.');
+        }
+
+        $this->code = $code;
+        $this->precision = $precision;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getPrecision(): int
+    {
+        return $this->precision;
+    }
+
+}

--- a/src/ValueObject/Amount.php
+++ b/src/ValueObject/Amount.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\ValueObject;
+
+use SomeWork\FeeCalculator\Currency\Currency;
+
+final class Amount
+{
+    private readonly Currency $currency;
+
+    private readonly string $value;
+
+    public function __construct(Currency $currency, string $value)
+    {
+        $this->currency = $currency;
+        $this->value = AmountNormalizer::normalize($value, $currency->getPrecision());
+    }
+
+    public static function fromString(string $value, Currency $currency): self
+    {
+        return new self($currency, $value);
+    }
+
+    public function getCurrency(): Currency
+    {
+        return $this->currency;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $amount): bool
+    {
+        if ($this->currency->getCode() !== $amount->currency->getCode()) {
+            return false;
+        }
+
+        return bccomp(
+            $this->value,
+            $amount->value,
+            $this->currency->getPrecision(),
+        ) === 0;
+    }
+}

--- a/src/ValueObject/AmountNormalizer.php
+++ b/src/ValueObject/AmountNormalizer.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\ValueObject;
+
+use InvalidArgumentException;
+
+final class AmountNormalizer
+{
+    public static function normalize(string $value, int $scale): string
+    {
+        $numeric = self::sanitizeNumeric($value);
+
+        return self::formatScale($numeric, $scale);
+    }
+
+    public static function enforceScale(string $value, int $scale): void
+    {
+        $numeric = self::sanitizeNumeric($value);
+
+        $normalized = self::formatScale($numeric, $scale);
+
+        $comparisonScale = max($scale, self::countDecimals($numeric));
+
+        if (bccomp($normalized, $numeric, $comparisonScale) !== 0) {
+            throw new InvalidArgumentException(sprintf(
+                'Value "%s" cannot be represented with scale of %d decimal places without losing precision.',
+                $value,
+                $scale,
+            ));
+        }
+    }
+
+    private static function assertNumeric(string $value): void
+    {
+        if (preg_match('/^-?(?:\d+)(?:\.\d+)?$/', $value) !== 1) {
+            throw new InvalidArgumentException(sprintf('Value "%s" is not a valid decimal string.', $value));
+        }
+    }
+
+    private static function sanitizeNumeric(string $value): string
+    {
+        $trimmed = self::trimWhitespace($value);
+
+        self::assertNumeric($trimmed);
+
+        return ltrim($trimmed, '+');
+    }
+
+    private static function trimWhitespace(string $value): string
+    {
+        return trim($value);
+    }
+
+    private static function formatScale(string $value, int $scale): string
+    {
+        if ($scale < 0) {
+            throw new InvalidArgumentException('Scale must be a positive integer.');
+        }
+
+        return bcadd($value, '0', $scale);
+    }
+
+    private static function countDecimals(string $value): int
+    {
+        $decimalPosition = strpos($value, '.');
+
+        if ($decimalPosition === false) {
+            return 0;
+        }
+
+        $decimalPart = substr($value, $decimalPosition + 1);
+        $trimmedDecimalPart = rtrim($decimalPart, '0');
+
+        return $trimmedDecimalPart === '' ? 0 : strlen($trimmedDecimalPart);
+    }
+}

--- a/tests/Unit/Currency/CurrencyTest.php
+++ b/tests/Unit/Currency/CurrencyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\Currency;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Currency\Currency;
+
+final class CurrencyTest extends TestCase
+{
+    public function testItStoresBasicData(): void
+    {
+        $currency = new Currency('usd', 2);
+
+        self::assertSame('USD', $currency->getCode());
+        self::assertSame(2, $currency->getPrecision());
+    }
+}

--- a/tests/Unit/ValueObject/AmountNormalizerTest.php
+++ b/tests/Unit/ValueObject/AmountNormalizerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\ValueObject;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\ValueObject\AmountNormalizer;
+
+final class AmountNormalizerTest extends TestCase
+{
+    public function testItNormalizesWithScale(): void
+    {
+        self::assertSame('10.50', AmountNormalizer::normalize('10.5', 2));
+    }
+
+    public function testItTrimsExcessiveScale(): void
+    {
+        self::assertSame('1.23', AmountNormalizer::normalize('01.2300', 2));
+    }
+
+    public function testItHandlesInsignificantZeros(): void
+    {
+        self::assertSame('0.00', AmountNormalizer::normalize('00.000010000', 2));
+    }
+
+    public function testEnforceScaleRejectsPrecisionLoss(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        AmountNormalizer::enforceScale('1.234', 2);
+    }
+
+    public function testEnforceScalePassesRepresentableValue(): void
+    {
+        AmountNormalizer::enforceScale('00.1000', 2);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEnforceScaleTreatsTrailingZerosAsInsignificant(): void
+    {
+        AmountNormalizer::enforceScale('1.2300', 2);
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/ValueObject/AmountTest.php
+++ b/tests/Unit/ValueObject/AmountTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SomeWork\FeeCalculator\Tests\Unit\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+use SomeWork\FeeCalculator\Currency\Currency;
+use SomeWork\FeeCalculator\ValueObject\Amount;
+
+final class AmountTest extends TestCase
+{
+    private Currency $currency;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currency = new Currency('USD', 2);
+    }
+
+    public function testItNormalizesValue(): void
+    {
+        $amount = new Amount($this->currency, '1');
+
+        self::assertSame('1.00', $amount->getValue());
+    }
+
+    public function testItHandlesValuesWithAdditionalZeros(): void
+    {
+        $amount = new Amount($this->currency, '00.000010000');
+
+        self::assertSame('0.00', $amount->getValue());
+    }
+
+    public function testEqualityRequiresSameCurrencyAndValue(): void
+    {
+        $amount = new Amount($this->currency, '1.00');
+        $same = new Amount($this->currency, '1.000');
+        $differentCurrency = new Amount(new Currency('EUR', 2), '1.00');
+        $differentValue = new Amount($this->currency, '2.00');
+
+        self::assertTrue($amount->equals($same));
+        self::assertFalse($amount->equals($differentCurrency));
+        self::assertFalse($amount->equals($differentValue));
+    }
+}


### PR DESCRIPTION
## Summary
- compare amount equality using `bccomp` so values match by numeric comparison rather than raw strings
- keep short-circuit on currency mismatches before performing the BC Math comparison

## Testing
- vendor/bin/phpunit --no-coverage *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dc075e9f2c8320865dd4be36ef6f54